### PR TITLE
Federated Preprocessing + Data Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # DRAGON Preprocessing
 This repository contains the preprocessing scripts for the [DRAGON challenge](https://dragon.grand-challenge.org/).
 
-If you are using this codebase or some part of it, please cite the following article:
-PENDING
+If you are using DRAGON resources, please cite the following article:
 
-**BibTeX:**
-```
-PENDING
-```
+> J. S. Bosma, …, H. Huisman for the DRAGON Consortium. The DRAGON benchmark for clinical NLP. *npj Digital Medicine* 8, 289 (2025). [https://doi.org/10.1038/s41746-025-01626-x](https://doi.org/10.1038/s41746-025-01626-x)
+
+Download the citation file for your reference manager: [BibTeX](https://github.com/DIAGNijmegen/dragon/blob/main/citation.bib) | [RIS](https://github.com/DIAGNijmegen/dragon/blob/main/citation.ris)
+
 
 ## Installation
 `dragon_prep` can be pip-installed:

--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,1 @@
-docker build . --tag dragon_prep:latest --tag dragon_prep:v0.2.8
+docker build . --tag dragon_prep:latest --tag dragon_prep:v0.2.9

--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,1 @@
-docker build . --tag dragon_prep:latest --tag dragon_prep:v0.2.6
+docker build . --tag dragon_prep:latest --tag dragon_prep:v0.2.7

--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,1 @@
-docker build . --tag dragon_prep:latest --tag dragon_prep:v0.2.7
+docker build . --tag dragon_prep:latest --tag dragon_prep:v0.2.8

--- a/preprocess_federated.sh
+++ b/preprocess_federated.sh
@@ -1,0 +1,78 @@
+docker run --rm \
+    -v /Users/joeranbosma/repos/dragon_data/rumc-jbz/chestct-lung-nodules:/input:ro \
+    -v /Users/joeranbosma/repos/dragon_data/preprocessed/federated:/output \
+    dragon_prep:latest python /opt/app/dragon_prep/src/dragon_prep/federated/Task002_nodule_clf.py
+
+docker run --rm \
+    -v /Users/joeranbosma/repos/dragon_data/rumc-jbz/recist:/input:ro \
+    -v /Users/joeranbosma/repos/dragon_data/preprocessed/federated:/output \
+    dragon_prep:latest python /opt/app/dragon_prep/src/dragon_prep/federated/Task005_recist_timeline_clf.py
+
+docker run --rm \
+    -v /Users/joeranbosma/repos/dragon_data/rumc-jbz/chestct-lung-nodules:/input:ro \
+    -v /Users/joeranbosma/repos/dragon_data/preprocessed/federated:/output \
+    dragon_prep:latest python /opt/app/dragon_prep/src/dragon_prep/federated/Task007_nodule_diameter_presence_clf.py
+
+docker run --rm \
+    -v /Users/joeranbosma/repos/dragon_data:/input:ro \
+    -v /Users/joeranbosma/repos/dragon_data/preprocessed/federated:/output \
+    dragon_prep:latest python /opt/app/dragon_prep/src/dragon_prep/federated/Task010_prostate_radiology_clf.py
+
+docker run --rm \
+    -v /Users/joeranbosma/repos/dragon_data:/input:ro \
+    -v /Users/joeranbosma/repos/dragon_data/preprocessed/federated:/output \
+    dragon_prep:latest python /opt/app/dragon_prep/src/dragon_prep/federated/Task011_prostate_pathology_clf.py
+
+docker run --rm \
+    -v /Users/joeranbosma/repos/dragon_data/rumc-jbz/recist:/input:ro \
+    -v /Users/joeranbosma/repos/dragon_data/preprocessed/federated:/output \
+    dragon_prep:latest python /opt/app/dragon_prep/src/dragon_prep/federated/Task016_recist_lesion_size_presence_clf.py
+
+docker run --rm \
+    -v /Users/joeranbosma/repos/dragon_data:/input:ro \
+    -v /Users/joeranbosma/repos/dragon_data/preprocessed/federated:/output \
+    dragon_prep:latest python /opt/app/dragon_prep/src/dragon_prep/federated/Task019_prostate_volume_reg.py
+
+docker run --rm \
+    -v /Users/joeranbosma/repos/dragon_data:/input:ro \
+    -v /Users/joeranbosma/repos/dragon_data/preprocessed/federated:/output \
+    dragon_prep:latest python /opt/app/dragon_prep/src/dragon_prep/federated/Task020_psa_reg.py
+
+docker run --rm \
+    -v /Users/joeranbosma/repos/dragon_data:/input:ro \
+    -v /Users/joeranbosma/repos/dragon_data/preprocessed/federated:/output \
+    dragon_prep:latest python /opt/app/dragon_prep/src/dragon_prep/federated/Task021_psad_reg.py
+
+docker run --rm \
+    -v /Users/joeranbosma/repos/dragon_data/rumc-jbz/chestct-lung-nodules:/input:ro \
+    -v /Users/joeranbosma/repos/dragon_data/preprocessed/federated:/output \
+    dragon_prep:latest python /opt/app/dragon_prep/src/dragon_prep/federated/Task023_nodule_diameter_reg.py
+
+docker run --rm \
+    -v /Users/joeranbosma/repos/dragon_data/rumc-jbz/recist:/input:ro \
+    -v /Users/joeranbosma/repos/dragon_data/preprocessed/federated:/output \
+    dragon_prep:latest python /opt/app/dragon_prep/src/dragon_prep/federated/Task024_recist_lesion_size_reg.py
+
+docker run --rm \
+    -v /Users/joeranbosma/repos/dragon_data:/input:ro \
+    -v /Users/joeranbosma/repos/dragon_data/preprocessed/federated:/output \
+    dragon_prep:latest python /opt/app/dragon_prep/src/dragon_prep/federated/Task025_anonymisation_ner.py
+
+docker run --rm \
+    -v /Users/joeranbosma/repos/dragon_data/preprocessed/federated/algorithm-input:/input/federated/algorithm-input \
+    -v /Users/joeranbosma/repos/dragon_data/preprocessed/algorithm-input:/input/algorithm-input:ro \
+    -v /Users/joeranbosma/repos/dragon_data/preprocessed/federated/debug-input:/output/federated/debug-input \
+    -v /Users/joeranbosma/repos/dragon_data/preprocessed/federated/debug-test-set:/output/federated/debug-test-set \
+    dragon_prep:latest python /opt/app/dragon_prep/src/dragon_prep/federated/make_debug_splits.py
+
+docker run --rm \
+    -v /Users/joeranbosma/repos/dragon_data/preprocessed/federated/algorithm-input:/input/federated/algorithm-input \
+    -v /Users/joeranbosma/repos/dragon_data/preprocessed/algorithm-input:/input/algorithm-input:ro \
+    -v /Users/joeranbosma/repos/dragon_data/preprocessed/federated/test-set:/input/federated/test-set \
+    -v /Users/joeranbosma/repos/dragon_data/preprocessed/test-set:/input/test-set:ro \
+    dragon_prep:latest python /opt/app/dragon_prep/src/dragon_prep/federated/make_test_splits.py
+
+docker run --rm \
+    -v /Users/joeranbosma/repos/dragon_data/preprocessed:/input:ro \
+    -v /Users/joeranbosma/repos/dragon_data/preprocessed/federated:/output \
+    dragon_prep:latest python /opt/app/dragon_prep/src/dragon_prep/federated/make_synthetic_splits.py

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,5 +3,6 @@ tox==4.18.1
 pytest==8.3.2
 pytest-cov==5.0.0
 mypy===1.11.2
-build==1.2.2
-twine==5.1.1
+build==1.2.2.post1
+twine==6.1.0
+packaging==24.2

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ if __name__ == '__main__':
         long_description = fh.read()
 
     setuptools.setup(
-        version='0.2.7',
+        version='0.2.8',
         author_email='Joeran.Bosma@radboudumc.nl',
         long_description=long_description,
         long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ if __name__ == '__main__':
         long_description = fh.read()
 
     setuptools.setup(
-        version='0.2.6',
+        version='0.2.7',
         author_email='Joeran.Bosma@radboudumc.nl',
         long_description=long_description,
         long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ if __name__ == '__main__':
         long_description = fh.read()
 
     setuptools.setup(
-        version='0.2.8',
+        version='0.2.9',
         author_email='Joeran.Bosma@radboudumc.nl',
         long_description=long_description,
         long_description_content_type="text/markdown",

--- a/src/dragon_prep/Task010_prostate_radiology_clf.py
+++ b/src/dragon_prep/Task010_prostate_radiology_clf.py
@@ -97,8 +97,8 @@ def preprocess_reports(
     assert set(df_umcg.patient_id) & set(df_avl.patient_id) == set()
     assert df_rumc.text.apply(lambda text: "<PERSOON>" in text).sum() > 1200, f"Unexpected number of <PERSOON> tags in RUMC reports: {df_rumc.text.apply(lambda text: '<PERSOON>' in text).sum()}"
     assert df_rumc.text.apply(lambda text: "<DATUM>" in text).sum() > 1200, f"Unexpected number of <DATUM> tags in RUMC reports: {df_rumc.text.apply(lambda text: '<DATUM>' in text).sum()}"
-    assert df_umcg.text.apply(lambda text: "<DATUM>" in text).sum() > 200, f"Unexpected number of <DATUM> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<DATUM>' in text).sum()}"
-    assert df_umcg.text.apply(lambda text: "<TIJD>" in text).sum() > 200, f"Unexpected number of <TIJD> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<TIJD>' in text).sum()}"
+    assert df_umcg.text.apply(lambda text: "<DATUM>" in text).sum() > 150, f"Unexpected number of <DATUM> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<DATUM>' in text).sum()}"
+    assert df_umcg.text.apply(lambda text: "<TIJD>" in text).sum() > 150, f"Unexpected number of <TIJD> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<TIJD>' in text).sum()}"
     assert df_avl.text.apply(lambda text: "<PERSOON>" in text).sum() > 200, f"Unexpected number of <PERSOON> tags in AVL reports: {df_avl.text.apply(lambda text: '<PERSOON>' in text).sum()}"
     assert df_avl.text.apply(lambda text: "<DATUM>" in text).sum() > 200, f"Unexpected number of <DATUM> tags in AVL reports: {df_avl.text.apply(lambda text: '<DATUM>' in text).sum()}"
     df = pd.concat((df_rumc[cols], df_umcg[cols], df_avl[cols]), ignore_index=True)

--- a/src/dragon_prep/Task011_prostate_pathology_clf.py
+++ b/src/dragon_prep/Task011_prostate_pathology_clf.py
@@ -140,6 +140,7 @@ def prepare_umcg_reports(
 
         umcg_entries.append({
             "label": sum([score >= 7 for score in scores]),
+            "lesion_GS": ",".join([f"{row.gg1}+{row.gg2}" for _, row in study_df.iterrows()]).replace("NA+NA", "N/A"),
             **study_df.iloc[0].to_dict(),
         })
 

--- a/src/dragon_prep/Task019_prostate_volume_reg.py
+++ b/src/dragon_prep/Task019_prostate_volume_reg.py
@@ -174,8 +174,8 @@ def preprocess_reports(
     assert set(df_umcg.patient_id) & set(df_avl.patient_id) == set()
     assert df_rumc.text.apply(lambda text: "<PERSOON>" in text).sum() > 1200, f"Unexpected number of <PERSOON> tags in RUMC reports: {df_rumc.text.apply(lambda text: '<PERSOON>' in text).sum()}"
     assert df_rumc.text.apply(lambda text: "<DATUM>" in text).sum() > 1200, f"Unexpected number of <DATUM> tags in RUMC reports: {df_rumc.text.apply(lambda text: '<DATUM>' in text).sum()}"
-    assert df_umcg.text.apply(lambda text: "<DATUM>" in text).sum() > 200, f"Unexpected number of <DATUM> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<DATUM>' in text).sum()}"
-    assert df_umcg.text.apply(lambda text: "<TIJD>" in text).sum() > 200, f"Unexpected number of <TIJD> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<TIJD>' in text).sum()}"
+    assert df_umcg.text.apply(lambda text: "<DATUM>" in text).sum() > 150, f"Unexpected number of <DATUM> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<DATUM>' in text).sum()}"
+    assert df_umcg.text.apply(lambda text: "<TIJD>" in text).sum() > 150, f"Unexpected number of <TIJD> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<TIJD>' in text).sum()}"
     assert df_avl.text.apply(lambda text: "<PERSOON>" in text).sum() > 200, f"Unexpected number of <PERSOON> tags in AVL reports: {df_avl.text.apply(lambda text: '<PERSOON>' in text).sum()}"
     assert df_avl.text.apply(lambda text: "<DATUM>" in text).sum() > 200, f"Unexpected number of <DATUM> tags in AVL reports: {df_avl.text.apply(lambda text: '<DATUM>' in text).sum()}"
     df = pd.concat((df_rumc[cols], df_umcg[cols], df_avl[cols]), ignore_index=True)

--- a/src/dragon_prep/Task019_prostate_volume_reg.py
+++ b/src/dragon_prep/Task019_prostate_volume_reg.py
@@ -175,9 +175,9 @@ def preprocess_reports(
     assert df_rumc.text.apply(lambda text: "<PERSOON>" in text).sum() > 1200, f"Unexpected number of <PERSOON> tags in RUMC reports: {df_rumc.text.apply(lambda text: '<PERSOON>' in text).sum()}"
     assert df_rumc.text.apply(lambda text: "<DATUM>" in text).sum() > 1200, f"Unexpected number of <DATUM> tags in RUMC reports: {df_rumc.text.apply(lambda text: '<DATUM>' in text).sum()}"
     assert df_umcg.text.apply(lambda text: "<DATUM>" in text).sum() > 150, f"Unexpected number of <DATUM> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<DATUM>' in text).sum()}"
-    assert df_umcg.text.apply(lambda text: "<TIJD>" in text).sum() > 150, f"Unexpected number of <TIJD> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<TIJD>' in text).sum()}"
-    assert df_avl.text.apply(lambda text: "<PERSOON>" in text).sum() > 200, f"Unexpected number of <PERSOON> tags in AVL reports: {df_avl.text.apply(lambda text: '<PERSOON>' in text).sum()}"
-    assert df_avl.text.apply(lambda text: "<DATUM>" in text).sum() > 200, f"Unexpected number of <DATUM> tags in AVL reports: {df_avl.text.apply(lambda text: '<DATUM>' in text).sum()}"
+    assert df_umcg.text.apply(lambda text: "<TIJD>" in text).sum() > 100, f"Unexpected number of <TIJD> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<TIJD>' in text).sum()}"
+    assert df_avl.text.apply(lambda text: "<PERSOON>" in text).sum() > 150, f"Unexpected number of <PERSOON> tags in AVL reports: {df_avl.text.apply(lambda text: '<PERSOON>' in text).sum()}"
+    assert df_avl.text.apply(lambda text: "<DATUM>" in text).sum() > 150, f"Unexpected number of <DATUM> tags in AVL reports: {df_avl.text.apply(lambda text: '<DATUM>' in text).sum()}"
     df = pd.concat((df_rumc[cols], df_umcg[cols], df_avl[cols]), ignore_index=True)
     print(f"Have {len(df)} radiology reports ({num_patients(df)} patients) in total")
 

--- a/src/dragon_prep/Task020_psa_reg.py
+++ b/src/dragon_prep/Task020_psa_reg.py
@@ -114,9 +114,9 @@ def preprocess_reports(
     assert df_rumc.text.apply(lambda text: "<PERSOON>" in text).sum() > 1200, f"Unexpected number of <PERSOON> tags in RUMC reports: {df_rumc.text.apply(lambda text: '<PERSOON>' in text).sum()}"
     assert df_rumc.text.apply(lambda text: "<DATUM>" in text).sum() > 1200, f"Unexpected number of <DATUM> tags in RUMC reports: {df_rumc.text.apply(lambda text: '<DATUM>' in text).sum()}"
     assert df_umcg.text.apply(lambda text: "<DATUM>" in text).sum() > 150, f"Unexpected number of <DATUM> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<DATUM>' in text).sum()}"
-    assert df_umcg.text.apply(lambda text: "<TIJD>" in text).sum() > 150, f"Unexpected number of <TIJD> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<TIJD>' in text).sum()}"
-    assert df_avl.text.apply(lambda text: "<PERSOON>" in text).sum() > 200, f"Unexpected number of <PERSOON> tags in AVL reports: {df_avl.text.apply(lambda text: '<PERSOON>' in text).sum()}"
-    assert df_avl.text.apply(lambda text: "<DATUM>" in text).sum() > 200, f"Unexpected number of <DATUM> tags in AVL reports: {df_avl.text.apply(lambda text: '<DATUM>' in text).sum()}"
+    assert df_umcg.text.apply(lambda text: "<TIJD>" in text).sum() > 100, f"Unexpected number of <TIJD> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<TIJD>' in text).sum()}"
+    assert df_avl.text.apply(lambda text: "<PERSOON>" in text).sum() > 150, f"Unexpected number of <PERSOON> tags in AVL reports: {df_avl.text.apply(lambda text: '<PERSOON>' in text).sum()}"
+    assert df_avl.text.apply(lambda text: "<DATUM>" in text).sum() > 150, f"Unexpected number of <DATUM> tags in AVL reports: {df_avl.text.apply(lambda text: '<DATUM>' in text).sum()}"
     df = pd.concat((df_rumc[cols], df_umcg[cols], df_avl[cols]), ignore_index=True)
     print(f"Have {len(df)} radiology reports ({num_patients(df)} patients) in total")
 

--- a/src/dragon_prep/Task020_psa_reg.py
+++ b/src/dragon_prep/Task020_psa_reg.py
@@ -113,8 +113,8 @@ def preprocess_reports(
     assert set(df_umcg.patient_id) & set(df_avl.patient_id) == set()
     assert df_rumc.text.apply(lambda text: "<PERSOON>" in text).sum() > 1200, f"Unexpected number of <PERSOON> tags in RUMC reports: {df_rumc.text.apply(lambda text: '<PERSOON>' in text).sum()}"
     assert df_rumc.text.apply(lambda text: "<DATUM>" in text).sum() > 1200, f"Unexpected number of <DATUM> tags in RUMC reports: {df_rumc.text.apply(lambda text: '<DATUM>' in text).sum()}"
-    assert df_umcg.text.apply(lambda text: "<DATUM>" in text).sum() > 200, f"Unexpected number of <DATUM> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<DATUM>' in text).sum()}"
-    assert df_umcg.text.apply(lambda text: "<TIJD>" in text).sum() > 200, f"Unexpected number of <TIJD> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<TIJD>' in text).sum()}"
+    assert df_umcg.text.apply(lambda text: "<DATUM>" in text).sum() > 150, f"Unexpected number of <DATUM> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<DATUM>' in text).sum()}"
+    assert df_umcg.text.apply(lambda text: "<TIJD>" in text).sum() > 150, f"Unexpected number of <TIJD> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<TIJD>' in text).sum()}"
     assert df_avl.text.apply(lambda text: "<PERSOON>" in text).sum() > 200, f"Unexpected number of <PERSOON> tags in AVL reports: {df_avl.text.apply(lambda text: '<PERSOON>' in text).sum()}"
     assert df_avl.text.apply(lambda text: "<DATUM>" in text).sum() > 200, f"Unexpected number of <DATUM> tags in AVL reports: {df_avl.text.apply(lambda text: '<DATUM>' in text).sum()}"
     df = pd.concat((df_rumc[cols], df_umcg[cols], df_avl[cols]), ignore_index=True)

--- a/src/dragon_prep/Task021_psad_reg.py
+++ b/src/dragon_prep/Task021_psad_reg.py
@@ -105,8 +105,8 @@ def preprocess_reports(
     assert set(df_umcg.patient_id) & set(df_avl.patient_id) == set()
     assert df_rumc.text.apply(lambda text: "<PERSOON>" in text).sum() > 1200, f"Unexpected number of <PERSOON> tags in RUMC reports: {df_rumc.text.apply(lambda text: '<PERSOON>' in text).sum()}"
     assert df_rumc.text.apply(lambda text: "<DATUM>" in text).sum() > 1200, f"Unexpected number of <DATUM> tags in RUMC reports: {df_rumc.text.apply(lambda text: '<DATUM>' in text).sum()}"
-    assert df_umcg.text.apply(lambda text: "<DATUM>" in text).sum() > 200, f"Unexpected number of <DATUM> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<DATUM>' in text).sum()}"
-    assert df_umcg.text.apply(lambda text: "<TIJD>" in text).sum() > 200, f"Unexpected number of <TIJD> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<TIJD>' in text).sum()}"
+    assert df_umcg.text.apply(lambda text: "<DATUM>" in text).sum() > 150, f"Unexpected number of <DATUM> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<DATUM>' in text).sum()}"
+    assert df_umcg.text.apply(lambda text: "<TIJD>" in text).sum() > 150, f"Unexpected number of <TIJD> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<TIJD>' in text).sum()}"
     assert df_avl.text.apply(lambda text: "<PERSOON>" in text).sum() > 200, f"Unexpected number of <PERSOON> tags in AVL reports: {df_avl.text.apply(lambda text: '<PERSOON>' in text).sum()}"
     assert df_avl.text.apply(lambda text: "<DATUM>" in text).sum() > 200, f"Unexpected number of <DATUM> tags in AVL reports: {df_avl.text.apply(lambda text: '<DATUM>' in text).sum()}"
     df = pd.concat((df_rumc[cols], df_umcg[cols], df_avl[cols]), ignore_index=True)

--- a/src/dragon_prep/Task021_psad_reg.py
+++ b/src/dragon_prep/Task021_psad_reg.py
@@ -106,9 +106,9 @@ def preprocess_reports(
     assert df_rumc.text.apply(lambda text: "<PERSOON>" in text).sum() > 1200, f"Unexpected number of <PERSOON> tags in RUMC reports: {df_rumc.text.apply(lambda text: '<PERSOON>' in text).sum()}"
     assert df_rumc.text.apply(lambda text: "<DATUM>" in text).sum() > 1200, f"Unexpected number of <DATUM> tags in RUMC reports: {df_rumc.text.apply(lambda text: '<DATUM>' in text).sum()}"
     assert df_umcg.text.apply(lambda text: "<DATUM>" in text).sum() > 150, f"Unexpected number of <DATUM> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<DATUM>' in text).sum()}"
-    assert df_umcg.text.apply(lambda text: "<TIJD>" in text).sum() > 150, f"Unexpected number of <TIJD> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<TIJD>' in text).sum()}"
-    assert df_avl.text.apply(lambda text: "<PERSOON>" in text).sum() > 200, f"Unexpected number of <PERSOON> tags in AVL reports: {df_avl.text.apply(lambda text: '<PERSOON>' in text).sum()}"
-    assert df_avl.text.apply(lambda text: "<DATUM>" in text).sum() > 200, f"Unexpected number of <DATUM> tags in AVL reports: {df_avl.text.apply(lambda text: '<DATUM>' in text).sum()}"
+    assert df_umcg.text.apply(lambda text: "<TIJD>" in text).sum() > 100, f"Unexpected number of <TIJD> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<TIJD>' in text).sum()}"
+    assert df_avl.text.apply(lambda text: "<PERSOON>" in text).sum() > 150, f"Unexpected number of <PERSOON> tags in AVL reports: {df_avl.text.apply(lambda text: '<PERSOON>' in text).sum()}"
+    assert df_avl.text.apply(lambda text: "<DATUM>" in text).sum() > 100, f"Unexpected number of <DATUM> tags in AVL reports: {df_avl.text.apply(lambda text: '<DATUM>' in text).sum()}"
     df = pd.concat((df_rumc[cols], df_umcg[cols], df_avl[cols]), ignore_index=True)
     print(f"Have {len(df)} radiology reports ({num_patients(df)} patients) in total")
 

--- a/src/dragon_prep/federated/Task002_nodule_clf.py
+++ b/src/dragon_prep/federated/Task002_nodule_clf.py
@@ -1,0 +1,64 @@
+#  Copyright 2022 Diagnostic Image Analysis Group, Radboudumc, Nijmegen, The Netherlands
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import argparse
+from pathlib import Path
+
+from dragon_prep.Task002_nodule_clf import preprocess_reports
+from dragon_prep.utils import read_anon, split_and_save_data
+
+
+def prepare_reports(
+    task_name: str,
+    output_dir: Path,
+):
+    # read anonynimized data
+    df_dev = read_anon(output_dir / "anon" / task_name / "nlp-development-dataset.json")
+    df_test = read_anon(output_dir / "anon" / task_name / "nlp-test-dataset.json")
+
+    # make test and cross-validation splits
+    df_dev["text_parts"] = df_dev.apply(lambda row: [row["hospital"], row["text"]], axis=1)
+    df_dev = df_dev.drop(columns=["hospital", "text"])
+    df_test["text_parts"] = df_test.apply(lambda row: [row["hospital"], row["text"]], axis=1)
+    df_test = df_test.drop(columns=["hospital", "text"])
+    split_and_save_data(
+        df=df_dev,
+        df_test=df_test,
+        output_dir=output_dir,
+        task_name=task_name,
+        split_by="PatientID",
+    )
+
+
+if __name__ == "__main__":
+    # create the parser
+    parser = argparse.ArgumentParser(description="Script for preparing reports")
+    parser.add_argument("--task_name", type=str, default="Task002_nodule_clf",
+                        help="Name of the task")
+    parser.add_argument("-i", "--input", type=Path, default=Path("/input"),
+                        help="Path to the input data")
+    parser.add_argument("-o", "--output", type=Path, default=Path("/output"),
+                        help="Folder to store the prepared reports in")
+    args = parser.parse_args()
+
+    # run preprocessing
+    preprocess_reports(
+        task_name=args.task_name,
+        input_dir=args.input,
+        output_dir=args.output,
+    )
+    prepare_reports(
+        task_name=args.task_name,
+        output_dir=args.output,
+    )

--- a/src/dragon_prep/federated/Task005_recist_timeline_clf.py
+++ b/src/dragon_prep/federated/Task005_recist_timeline_clf.py
@@ -1,0 +1,102 @@
+#  Copyright 2022 Diagnostic Image Analysis Group, Radboudumc, Nijmegen, The Netherlands
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+from dragon_prep.utils import prepare_for_anon, read_anon, split_and_save_data
+
+
+def preprocess_reports(
+    task_name: str,
+    input_dir: Path,
+    output_dir: Path,
+):
+    # read marksheets
+    df_jbz = pd.read_excel(input_dir / "JBZ_RECIST_cases_JB_MG.xlsx", dtype=str)
+    df_rumc = pd.read_excel(input_dir / "RadboudUMC_RECIST_cases_MG.xlsx", dtype=str)
+
+    # sanity check
+    assert df_jbz["is_baseline"].isna().sum() == 0
+    assert df_rumc["baseline_scan"].isna().sum() == 0
+    assert set(df_jbz["is_baseline"].unique()) == {"t", "f"}
+    assert set(df_rumc["baseline_scan"].unique()) == {"t", "f"}
+
+    # rename columns
+    df_rumc = df_rumc.rename(columns={"anon_patientid": "PatientID", "anon_studyinstanceuid": "StudyInstanceUID", "baseline_scan": "is_baseline"})
+    df_rumc["text"] = df_rumc["raw_text"]
+
+    # add center
+    df_rumc["center"] = "RUMC"
+    df_jbz["center"] = "JBZ"
+
+    # merge datasets and select relevant columns
+    cols = ["PatientID", "text", "is_baseline", "StudyInstanceUID", "center"]
+    df = pd.concat([df_jbz[cols], df_rumc[cols]], axis=0, ignore_index=True)
+    df["uid"] = df["StudyInstanceUID"]
+
+    # make label
+    df["single_label_binary_classification_target"] = (df["is_baseline"] == "t")
+
+    # prepare for anonynimization
+    prepare_for_anon(df=df, output_dir=output_dir, task_name=task_name)
+
+
+def prepare_reports(
+    task_name: str,
+    output_dir: Path,
+    test_split_size: float = 0.3,
+):
+    # read anonynimized data
+    df = read_anon(output_dir / "anon" / task_name / "nlp-dataset.json")
+
+    # make test and cross-validation splits
+    df["text_parts"] = df.apply(lambda row: [row["center"], row["text"]], axis=1)
+    df = df.drop(columns=["center", "text"])
+    split_and_save_data(
+        df=df,
+        output_dir=output_dir,
+        task_name=task_name,
+        test_split_size=test_split_size,
+        split_by="PatientID",
+        recommended_truncation_side="right",
+    )
+
+
+if __name__ == "__main__":
+    # create the parser
+    parser = argparse.ArgumentParser(description="Script for preparing reports")
+    parser.add_argument("--task_name", type=str, default="Task005_recist_timeline_clf",
+                        help="Name of the task")
+    parser.add_argument("-i", "--input", type=Path, default=Path("/input"),
+                        help="Path to the input data")
+    parser.add_argument("-o", "--output", type=Path, default=Path("/output"),
+                        help="Folder to store the prepared reports in")
+    parser.add_argument("--test_split_size", type=float, default=0.3,
+                        help="Fraction of the dataset to use for testing")
+    args = parser.parse_args()
+
+    # run preprocessing
+    preprocess_reports(
+        task_name=args.task_name,
+        input_dir=args.input,
+        output_dir=args.output,
+    )
+    prepare_reports(
+        task_name=args.task_name,
+        output_dir=args.output,
+        test_split_size=args.test_split_size,
+    )

--- a/src/dragon_prep/federated/Task007_nodule_diameter_presence_clf.py
+++ b/src/dragon_prep/federated/Task007_nodule_diameter_presence_clf.py
@@ -1,0 +1,64 @@
+#  Copyright 2022 Diagnostic Image Analysis Group, Radboudumc, Nijmegen, The Netherlands
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import argparse
+from pathlib import Path
+
+from dragon_prep.Task007_nodule_diameter_presence_clf import preprocess_reports
+from dragon_prep.utils import read_anon, split_and_save_data
+
+
+def prepare_reports(
+    task_name: str,
+    output_dir: Path,
+):
+    # read anonynimized data
+    df_dev = read_anon(output_dir / "anon" / task_name / "nlp-development-dataset.json")
+    df_test = read_anon(output_dir / "anon" / task_name / "nlp-test-dataset.json")
+
+    # make test and cross-validation splits
+    df_dev["text_parts"] = df_dev.apply(lambda row: [row["hospital"], row["text"]], axis=1)
+    df_dev = df_dev.drop(columns=["hospital", "text"])
+    df_test["text_parts"] = df_test.apply(lambda row: [row["hospital"], row["text"]], axis=1)
+    df_test = df_test.drop(columns=["hospital", "text"])
+    split_and_save_data(
+        df=df_dev,
+        df_test=df_test,
+        output_dir=output_dir,
+        task_name=task_name,
+        split_by="PatientID",
+    )
+
+
+if __name__ == "__main__":
+    # create the parser
+    parser = argparse.ArgumentParser(description="Script for preparing reports")
+    parser.add_argument("--task_name", type=str, default="Task007_nodule_diameter_presence_clf",
+                        help="Name of the task")
+    parser.add_argument("-i", "--input", type=Path, default=Path("/input"),
+                        help="Path to the input data")
+    parser.add_argument("-o", "--output", type=Path, default=Path("/output"),
+                        help="Folder to store the prepared reports in")
+    args = parser.parse_args()
+
+    # run preprocessing
+    preprocess_reports(
+        task_name=args.task_name,
+        input_dir=args.input,
+        output_dir=args.output,
+    )
+    prepare_reports(
+        task_name=args.task_name,
+        output_dir=args.output,
+    )

--- a/src/dragon_prep/federated/Task010_prostate_radiology_clf.py
+++ b/src/dragon_prep/federated/Task010_prostate_radiology_clf.py
@@ -1,0 +1,110 @@
+#  Copyright 2022 Diagnostic Image Analysis Group, Radboudumc, Nijmegen, The Netherlands
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+from dragon_prep.Task010_prostate_radiology_clf import (
+    preprocess_reports_avl, preprocess_reports_rumc, preprocess_reports_umcg)
+from dragon_prep.utils import (num_patients, prepare_for_anon, read_anon,
+                               split_and_save_data)
+
+
+def preprocess_reports(
+    task_name: str,
+    input_dir: Path,
+    output_dir: Path,
+):
+    # read PI-CAI marksheet for RUMC reports
+    df_rumc = preprocess_reports_rumc(input_dir / "rumc/prostate")
+    print(f"Have {len(df_rumc)} radiology reports ({num_patients(df_rumc)} patients) from RUMC")
+    df_rumc["center"] = "RUMC"
+
+    # # read UMCG marksheet for UMCG reports
+    df_umcg = preprocess_reports_umcg(input_dir / "umcg/prostate/radiology")
+    print(f"Have {len(df_umcg)} radiology reports ({num_patients(df_umcg)} patients) from UMCG")
+    df_umcg["center"] = "UMCG"
+
+    # read AVL marksheet for AVL reports
+    df_avl = preprocess_reports_avl(input_dir / "avl/prostate/radiology")
+    print(f"Have {len(df_avl)} radiology reports ({num_patients(df_avl)} patients) from AVL")
+    df_avl["center"] = "AVL"
+
+    # merge dataframes
+    cols = ["uid", "patient_id", "study_id", "label", "text", "center"]
+    assert set(df_rumc.patient_id) & set(df_umcg.patient_id) == set()
+    assert set(df_rumc.patient_id) & set(df_avl.patient_id) == set()
+    assert set(df_umcg.patient_id) & set(df_avl.patient_id) == set()
+    assert df_rumc.text.apply(lambda text: "<PERSOON>" in text).sum() > 1200, f"Unexpected number of <PERSOON> tags in RUMC reports: {df_rumc.text.apply(lambda text: '<PERSOON>' in text).sum()}"
+    assert df_rumc.text.apply(lambda text: "<DATUM>" in text).sum() > 1200, f"Unexpected number of <DATUM> tags in RUMC reports: {df_rumc.text.apply(lambda text: '<DATUM>' in text).sum()}"
+    assert df_umcg.text.apply(lambda text: "<DATUM>" in text).sum() > 150, f"Unexpected number of <DATUM> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<DATUM>' in text).sum()}"
+    assert df_umcg.text.apply(lambda text: "<TIJD>" in text).sum() > 150, f"Unexpected number of <TIJD> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<TIJD>' in text).sum()}"
+    assert df_avl.text.apply(lambda text: "<PERSOON>" in text).sum() > 150, f"Unexpected number of <PERSOON> tags in AVL reports: {df_avl.text.apply(lambda text: '<PERSOON>' in text).sum()}"
+    assert df_avl.text.apply(lambda text: "<DATUM>" in text).sum() > 150, f"Unexpected number of <DATUM> tags in AVL reports: {df_avl.text.apply(lambda text: '<DATUM>' in text).sum()}"
+    df = pd.concat((df_rumc[cols], df_umcg[cols], df_avl[cols]), ignore_index=True)
+    print(f"Have {len(df)} radiology reports ({num_patients(df)} patients) in total")
+
+    # prepare labels
+    df["label"] = df["label"].astype(str)
+    df = df.rename(columns={"label": "single_label_multi_class_classification_target"})
+
+    # prepare for anonynimization
+    prepare_for_anon(df=df, output_dir=output_dir, task_name=task_name, tag_phi=False, apply_hips=True)
+
+
+def prepare_reports(
+    task_name: str,
+    output_dir: Path,
+    test_split_size: float = 0.3,
+):
+    # read anonynimized data
+    df = read_anon(output_dir / "anon" / task_name / "nlp-dataset.json")
+
+    # make test and cross-validation splits
+    df["text_parts"] = df.apply(lambda row: [row["center"], row["text"]], axis=1)
+    df = df.drop(columns=["center", "text"])
+    split_and_save_data(
+        df=df,
+        output_dir=output_dir,
+        task_name=task_name,
+        test_split_size=test_split_size,
+    )
+
+
+if __name__ == "__main__":
+    # create the parser
+    parser = argparse.ArgumentParser(description="Script for preparing reports")
+    parser.add_argument("--task_name", type=str, default="Task010_prostate_radiology_clf",
+                        help="Name of the task")
+    parser.add_argument("-i", "--input", type=Path, default=Path("/input"),
+                        help="Path to the input data")
+    parser.add_argument("-o", "--output", type=Path, default=Path("/output"),
+                        help="Folder to store the prepared reports in")
+    parser.add_argument("--test_split_size", type=float, default=0.3,
+                        help="Fraction of the dataset to use for testing")
+    args = parser.parse_args()
+
+    # run preprocessing
+    preprocess_reports(
+        task_name=args.task_name,
+        input_dir=args.input,
+        output_dir=args.output,
+    )
+    prepare_reports(
+        task_name=args.task_name,
+        output_dir=args.output,
+        test_split_size=args.test_split_size,
+    )

--- a/src/dragon_prep/federated/Task011_prostate_pathology_clf.py
+++ b/src/dragon_prep/federated/Task011_prostate_pathology_clf.py
@@ -1,0 +1,114 @@
+#  Copyright 2022 Diagnostic Image Analysis Group, Radboudumc, Nijmegen, The Netherlands
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+from dragon_prep.Task011_prostate_pathology_clf import (prepare_avl_reports,
+                                                        prepare_rumc_reports,
+                                                        prepare_umcg_reports)
+from dragon_prep.utils import (num_patients, prepare_for_anon, read_anon,
+                               split_and_save_data)
+
+
+def preprocess_reports(
+    task_name: str,
+    input_dir: Path,
+    output_dir: Path,
+):
+    # read RUMC marksheet
+    df_rumc = prepare_rumc_reports(input_dir / "rumc/prostate")
+    print(f"Have {len(df_rumc)} cases ({num_patients(df_rumc)} patients) from RUMC")
+    df_rumc["center"] = "RUMC"
+
+    # read UMCG marksheet
+    df_umcg = prepare_umcg_reports(input_dir / "umcg/prostate/pathology")
+    print(f"Have {len(df_umcg)} cases ({num_patients(df_umcg)} patients) from UMCG")
+    df_umcg["center"] = "UMCG"
+
+    # read AvL marksheet
+    df_avl = prepare_avl_reports(input_dir / "avl/prostate/pathology")
+    print(f"Have {len(df_avl)} cases ({num_patients(df_avl)} patients) from AVL")
+    df_avl["center"] = "AVL"
+
+    # merge dataframes
+    cols = ["uid", "patient_id", "study_id", "label", "text", "center"]
+    assert set(df_rumc.patient_id) & set(df_umcg.patient_id) == set()
+    assert set(df_rumc.patient_id) & set(df_avl.patient_id) == set()
+    assert set(df_umcg.patient_id) & set(df_avl.patient_id) == set()
+    df = pd.concat((df_rumc[cols], df_umcg[cols], df_avl[cols]), ignore_index=True)
+    print(f"Have {len(df)} cases ({num_patients(df)} patients) in total")
+
+    # exclude cases with label 4, as there are only 7 of them
+    assert len(df[df["label"] == 4]) == 7, f"Unexpected number of cases with label 4, found {len(df[df['label'] == 4])}"
+    df = df[df["label"] != 4]
+    print(f"Have {len(df)} cases ({num_patients(df)} patients) after excluding label 4")
+
+    # prepare labels
+    df["label"] = df["label"].astype(str)
+    df.rename(columns={"label": "single_label_multi_class_classification_target"}, inplace=True)
+
+    # prepare for anonynimization
+    assert df.text.apply(lambda text: "<PERSOON>" in text).sum() > 600, f"Unexpected number of <PERSOON> tags in RUMC reports: {df.text.apply(lambda text: '<PERSOON>' in text).sum()}"
+    assert df.text.apply(lambda text: "<PERSOONAFKORTING>" in text).sum() > 1500, \
+        f"Unexpected number of <PERSOONAFKORTING> tags in RUMC reports: {df.text.apply(lambda text: '<PERSOONAFKORTING>' in text).sum()}"
+    assert df.text.apply(lambda text: "<DATUM>" in text).sum() > 1500, f"Unexpected number of <DATUM> tags in RUMC reports: {df.text.apply(lambda text: '<DATUM>' in text).sum()}"
+    prepare_for_anon(df=df, output_dir=output_dir, task_name=task_name, tag_phi=False, apply_hips=True)
+
+
+def prepare_reports(
+    task_name: str,
+    output_dir: Path,
+    test_split_size: float = 0.3,
+):
+    # read anonynimized data
+    df = read_anon(output_dir / "anon" / task_name / "nlp-dataset.json")
+
+    # make test and cross-validation splits
+    df["text_parts"] = df.apply(lambda row: [row["center"], row["text"]], axis=1)
+    df = df.drop(columns=["center", "text"])
+    split_and_save_data(
+        df=df,
+        output_dir=output_dir,
+        task_name=task_name,
+        test_split_size=test_split_size,
+    )
+
+
+if __name__ == "__main__":
+    # create the parser
+    parser = argparse.ArgumentParser(description="Script for preparing reports")
+    parser.add_argument("--task_name", type=str, default="Task011_prostate_pathology_clf",
+                        help="Name of the task")
+    parser.add_argument("-i", "--input", type=Path, default=Path("/input"),
+                        help="Path to the input data")
+    parser.add_argument("-o", "--output", type=Path, default=Path("/output"),
+                        help="Folder to store the prepared reports in")
+    parser.add_argument("--test_split_size", type=float, default=0.3,
+                        help="Fraction of the dataset to use for testing")
+    args = parser.parse_args()
+
+    # run preprocessing
+    preprocess_reports(
+        task_name=args.task_name,
+        input_dir=args.input,
+        output_dir=args.output,
+    )
+    prepare_reports(
+        task_name=args.task_name,
+        output_dir=args.output,
+        test_split_size=args.test_split_size,
+    )

--- a/src/dragon_prep/federated/Task016_recist_lesion_size_presence_clf.py
+++ b/src/dragon_prep/federated/Task016_recist_lesion_size_presence_clf.py
@@ -1,0 +1,98 @@
+#  Copyright 2022 Diagnostic Image Analysis Group, Radboudumc, Nijmegen, The Netherlands
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+from dragon_prep.utils import prepare_for_anon, read_anon, split_and_save_data
+
+
+def preprocess_reports(
+    task_name: str,
+    input_dir: Path,
+    output_dir: Path,
+):
+    # read marksheets
+    df_jbz = pd.read_excel(input_dir / "JBZ_RECIST_cases_JB_MG.xlsx", dtype=str)
+    df_rumc = pd.read_excel(input_dir / "RadboudUMC_RECIST_cases_MG.xlsx", dtype=str)
+
+    # rename columns
+    df_jbz = df_jbz.rename(columns={f"tl{i}_size": f"l{i}_size" for i in range(1, 20)})
+    df_rumc = df_rumc.rename(columns={"anon_patientid": "PatientID", "anon_studyinstanceuid": "StudyInstanceUID"} | {f"L{i}_size": f"l{i}_size" for i in range(1, 7)})
+    df_rumc["text"] = df_rumc["raw_text"]
+
+    # add center
+    df_rumc["center"] = "RUMC"
+    df_jbz["center"] = "JBZ"
+
+    # merge datasets and select relevant columns
+    cols = ["PatientID", "text", "StudyInstanceUID", "center"] + [f"l{i}_size" for i in range(1, 6)]
+    df = pd.concat([df_jbz[cols], df_rumc[cols]], axis=0, ignore_index=True)
+    df["uid"] = df["StudyInstanceUID"]
+
+    # make label
+    df["multi_label_binary_classification_target"] = df.apply(lambda row: [
+        row.notna()[f"l{i}_size"] for i in range(1, 5+1)
+        ], axis=1
+    )
+
+    # prepare for anonynimization
+    prepare_for_anon(df=df, output_dir=output_dir, task_name=task_name)
+
+
+def prepare_reports(
+    task_name: str,
+    output_dir: Path,
+    test_split_size: float = 0.3,
+):
+    # read anonynimized data
+    df = read_anon(output_dir / "anon" / task_name / "nlp-dataset.json")
+
+    # make test and cross-validation splits
+    df["text_parts"] = df.apply(lambda row: [row["center"], row["text"]], axis=1)
+    df = df.drop(columns=["center", "text"])
+    split_and_save_data(
+        df=df,
+        output_dir=output_dir,
+        task_name=task_name,
+        test_split_size=test_split_size,
+        split_by="PatientID",
+    )
+
+
+if __name__ == "__main__":
+    # create the parser
+    parser = argparse.ArgumentParser(description="Script for preparing reports")
+    parser.add_argument("--task_name", type=str, default="Task016_recist_lesion_size_presence_clf",
+                        help="Name of the task")
+    parser.add_argument("-i", "--input", type=Path, default=Path("/input"),
+                        help="Path to the input data")
+    parser.add_argument("-o", "--output", type=Path, default=Path("/output"),
+                        help="Folder to store the prepared reports in")
+    parser.add_argument("--test_split_size", type=float, default=0.3,
+                        help="Fraction of the dataset to use for testing")
+    args = parser.parse_args()
+
+    # run preprocessing
+    preprocess_reports(
+        task_name=args.task_name,
+        input_dir=args.input,
+        output_dir=args.output,
+    )
+    prepare_reports(
+        task_name=args.task_name,
+        output_dir=args.output,
+    )

--- a/src/dragon_prep/federated/Task019_prostate_volume_reg.py
+++ b/src/dragon_prep/federated/Task019_prostate_volume_reg.py
@@ -1,0 +1,112 @@
+#  Copyright 2022 Diagnostic Image Analysis Group, Radboudumc, Nijmegen, The Netherlands
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+from dragon_prep.Task019_prostate_volume_reg import (preprocess_reports_avl,
+                                                     preprocess_reports_rumc,
+                                                     preprocess_reports_umcg)
+from dragon_prep.utils import (num_patients, prepare_for_anon, read_anon,
+                               split_and_save_data)
+
+
+def preprocess_reports(
+    task_name: str,
+    input_dir: Path,
+    output_dir: Path,
+):
+    # read PI-CAI marksheet for RUMC reports
+    df_rumc = preprocess_reports_rumc(input_dir / "rumc/prostate")
+    print(f"Have {len(df_rumc)} radiology reports ({num_patients(df_rumc)} patients) for RUMC")
+    df_rumc["center"] = "RUMC"
+
+    # # read UMCG marksheet for UMCG reports
+    df_umcg = preprocess_reports_umcg(input_dir / "umcg/prostate/radiology")
+    print(f"Have {len(df_umcg)} radiology reports ({num_patients(df_umcg)} patients) for UMCG")
+    df_umcg["center"] = "UMCG"
+
+    # read AVL marksheet for AVL reports
+    df_avl = preprocess_reports_avl(input_dir / "avl/prostate/radiology")
+    print(f"Have {len(df_avl)} radiology reports ({num_patients(df_avl)} patients) for AVL")
+    df_avl["center"] = "AVL"
+
+    # merge dataframes
+    cols = ["uid", "patient_id", "study_id", "label", "text", "center"]
+    assert set(df_rumc.patient_id) & set(df_umcg.patient_id) == set()
+    assert set(df_rumc.patient_id) & set(df_avl.patient_id) == set()
+    assert set(df_umcg.patient_id) & set(df_avl.patient_id) == set()
+    assert df_rumc.text.apply(lambda text: "<PERSOON>" in text).sum() > 1200, f"Unexpected number of <PERSOON> tags in RUMC reports: {df_rumc.text.apply(lambda text: '<PERSOON>' in text).sum()}"
+    assert df_rumc.text.apply(lambda text: "<DATUM>" in text).sum() > 1200, f"Unexpected number of <DATUM> tags in RUMC reports: {df_rumc.text.apply(lambda text: '<DATUM>' in text).sum()}"
+    assert df_umcg.text.apply(lambda text: "<DATUM>" in text).sum() > 150, f"Unexpected number of <DATUM> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<DATUM>' in text).sum()}"
+    assert df_umcg.text.apply(lambda text: "<TIJD>" in text).sum() > 150, f"Unexpected number of <TIJD> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<TIJD>' in text).sum()}"
+    assert df_avl.text.apply(lambda text: "<PERSOON>" in text).sum() > 150, f"Unexpected number of <PERSOON> tags in AVL reports: {df_avl.text.apply(lambda text: '<PERSOON>' in text).sum()}"
+    assert df_avl.text.apply(lambda text: "<DATUM>" in text).sum() > 150, f"Unexpected number of <DATUM> tags in AVL reports: {df_avl.text.apply(lambda text: '<DATUM>' in text).sum()}"
+    df = pd.concat((df_rumc[cols], df_umcg[cols], df_avl[cols]), ignore_index=True)
+    print(f"Have {len(df)} radiology reports ({num_patients(df)} patients) in total")
+
+    # prepare labels
+    df["label"] = df["label"].astype(float)
+    df = df.rename(columns={"label": "single_label_regression_target"})
+
+    # prepare for anonynimization
+    prepare_for_anon(df=df, output_dir=output_dir, task_name=task_name, tag_phi=False, apply_hips=True)
+
+
+def prepare_reports(
+    task_name: str,
+    output_dir: Path,
+    test_split_size: float = 0.3,
+):
+    # read anonynimized data
+    df = read_anon(output_dir / "anon" / task_name / "nlp-dataset.json")
+
+    # make test and cross-validation splits
+    df["text_parts"] = df.apply(lambda row: [row["center"], row["text"]], axis=1)
+    df = df.drop(columns=["center", "text"])
+    split_and_save_data(
+        df=df,
+        output_dir=output_dir,
+        task_name=task_name,
+        test_split_size=test_split_size,
+        recommended_truncation_side="right",
+    )
+
+
+if __name__ == "__main__":
+    # create the parser
+    parser = argparse.ArgumentParser(description="Script for preparing reports")
+    parser.add_argument("--task_name", type=str, default="Task019_prostate_volume_reg",
+                        help="Name of the task")
+    parser.add_argument("-i", "--input", type=Path, default=Path("/input"),
+                        help="Path to the input data")
+    parser.add_argument("-o", "--output", type=Path, default=Path("/output"),
+                        help="Folder to store the prepared reports in")
+    parser.add_argument("--test_split_size", type=float, default=0.3,
+                        help="Fraction of the dataset to use for testing")
+    args = parser.parse_args()
+
+    # run preprocessing
+    preprocess_reports(
+        task_name=args.task_name,
+        input_dir=args.input,
+        output_dir=args.output,
+    )
+    prepare_reports(
+        task_name=args.task_name,
+        output_dir=args.output,
+        test_split_size=args.test_split_size,
+    )

--- a/src/dragon_prep/federated/Task020_psa_reg.py
+++ b/src/dragon_prep/federated/Task020_psa_reg.py
@@ -1,0 +1,112 @@
+#  Copyright 2022 Diagnostic Image Analysis Group, Radboudumc, Nijmegen, The Netherlands
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+from dragon_prep.Task020_psa_reg import (preprocess_reports_avl,
+                                         preprocess_reports_rumc,
+                                         preprocess_reports_umcg)
+from dragon_prep.utils import (num_patients, prepare_for_anon, read_anon,
+                               split_and_save_data)
+
+
+def preprocess_reports(
+    task_name: str,
+    input_dir: Path,
+    output_dir: Path,
+):
+    # read PI-CAI marksheet for RUMC reports
+    df_rumc = preprocess_reports_rumc(input_dir / "rumc/prostate")
+    print(f"Have {len(df_rumc)} cases ({num_patients(df_rumc)} patients) for RUMC")
+    df_rumc["center"] = "RUMC"
+
+    # # read UMCG marksheet for UMCG reports
+    df_umcg = preprocess_reports_umcg(input_dir / "umcg/prostate/radiology")
+    print(f"Have {len(df_umcg)} cases ({num_patients(df_umcg)} patients) for UMCG")
+    df_umcg["center"] = "UMCG"
+
+    # read AVL marksheet for AVL reports
+    df_avl = preprocess_reports_avl(input_dir / "avl/prostate/radiology")
+    print(f"Have {len(df_avl)} cases ({num_patients(df_avl)} patients) for AVL")
+    df_avl["center"] = "AVL"
+
+    # merge dataframes
+    cols = ["uid", "patient_id", "study_id", "label", "text", "center"]
+    assert set(df_rumc.patient_id) & set(df_umcg.patient_id) == set()
+    assert set(df_rumc.patient_id) & set(df_avl.patient_id) == set()
+    assert set(df_umcg.patient_id) & set(df_avl.patient_id) == set()
+    assert df_rumc.text.apply(lambda text: "<PERSOON>" in text).sum() > 1200, f"Unexpected number of <PERSOON> tags in RUMC reports: {df_rumc.text.apply(lambda text: '<PERSOON>' in text).sum()}"
+    assert df_rumc.text.apply(lambda text: "<DATUM>" in text).sum() > 1200, f"Unexpected number of <DATUM> tags in RUMC reports: {df_rumc.text.apply(lambda text: '<DATUM>' in text).sum()}"
+    assert df_umcg.text.apply(lambda text: "<DATUM>" in text).sum() > 150, f"Unexpected number of <DATUM> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<DATUM>' in text).sum()}"
+    assert df_umcg.text.apply(lambda text: "<TIJD>" in text).sum() > 100, f"Unexpected number of <TIJD> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<TIJD>' in text).sum()}"
+    assert df_avl.text.apply(lambda text: "<PERSOON>" in text).sum() > 150, f"Unexpected number of <PERSOON> tags in AVL reports: {df_avl.text.apply(lambda text: '<PERSOON>' in text).sum()}"
+    assert df_avl.text.apply(lambda text: "<DATUM>" in text).sum() > 150, f"Unexpected number of <DATUM> tags in AVL reports: {df_avl.text.apply(lambda text: '<DATUM>' in text).sum()}"
+    df = pd.concat((df_rumc[cols], df_umcg[cols], df_avl[cols]), ignore_index=True)
+    print(f"Have {len(df)} radiology reports ({num_patients(df)} patients) in total")
+
+    # prepare labels
+    df["label"] = df["label"].astype(float)
+    df = df.rename(columns={"label": "single_label_regression_target"})
+
+    # prepare for anonynimization
+    prepare_for_anon(df=df, output_dir=output_dir, task_name=task_name, tag_phi=False, apply_hips=True)
+
+
+def prepare_reports(
+    task_name: str,
+    output_dir: Path,
+    test_split_size: float = 0.3,
+):
+    # read anonynimized data
+    df = read_anon(output_dir / "anon" / task_name / "nlp-dataset.json")
+
+    # make test and cross-validation splits
+    df["text_parts"] = df.apply(lambda row: [row["center"], row["text"]], axis=1)
+    df = df.drop(columns=["center", "text"])
+    split_and_save_data(
+        df=df,
+        output_dir=output_dir,
+        task_name=task_name,
+        test_split_size=test_split_size,
+        recommended_truncation_side="right",
+    )
+
+
+if __name__ == "__main__":
+    # create the parser
+    parser = argparse.ArgumentParser(description="Script for preparing reports")
+    parser.add_argument("--task_name", type=str, default="Task020_psa_reg",
+                        help="Name of the task")
+    parser.add_argument("-i", "--input", type=Path, default=Path("/input"),
+                        help="Path to the input data")
+    parser.add_argument("-o", "--output", type=Path, default=Path("/output"),
+                        help="Folder to store the prepared reports in")
+    parser.add_argument("--test_split_size", type=float, default=0.3,
+                        help="Fraction of the dataset to use for testing")
+    args = parser.parse_args()
+
+    # run preprocessing
+    preprocess_reports(
+        task_name=args.task_name,
+        input_dir=args.input,
+        output_dir=args.output,
+    )
+    prepare_reports(
+        task_name=args.task_name,
+        output_dir=args.output,
+        test_split_size=args.test_split_size,
+    )

--- a/src/dragon_prep/federated/Task021_psad_reg.py
+++ b/src/dragon_prep/federated/Task021_psad_reg.py
@@ -1,0 +1,112 @@
+#  Copyright 2022 Diagnostic Image Analysis Group, Radboudumc, Nijmegen, The Netherlands
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+from dragon_prep.Task021_psad_reg import (preprocess_reports_avl,
+                                          preprocess_reports_rumc,
+                                          preprocess_reports_umcg)
+from dragon_prep.utils import (num_patients, prepare_for_anon, read_anon,
+                               split_and_save_data)
+
+
+def preprocess_reports(
+    task_name: str,
+    input_dir: Path,
+    output_dir: Path,
+):
+    # read PI-CAI marksheet for RUMC reports
+    df_rumc = preprocess_reports_rumc(input_dir / "rumc/prostate")
+    print(f"Have {len(df_rumc)} cases ({num_patients(df_rumc)} patients) from RUMC")
+    df_rumc["center"] = "RUMC"
+
+    # # read UMCG marksheet for UMCG reports
+    df_umcg = preprocess_reports_umcg(input_dir / "umcg/prostate/radiology")
+    print(f"Have {len(df_umcg)} cases ({num_patients(df_umcg)} patients) from UMCG")
+    df_umcg["center"] = "UMCG"
+
+    # read AVL marksheet for AVL reports
+    df_avl = preprocess_reports_avl(input_dir / "avl/prostate/radiology")
+    print(f"Have {len(df_avl)} cases ({num_patients(df_avl)} patients) from AVL")
+    df_avl["center"] = "AVL"
+
+    # merge dataframes
+    cols = ["uid", "patient_id", "study_id", "label", "text", "center"]
+    assert set(df_rumc.patient_id) & set(df_umcg.patient_id) == set()
+    assert set(df_rumc.patient_id) & set(df_avl.patient_id) == set()
+    assert set(df_umcg.patient_id) & set(df_avl.patient_id) == set()
+    assert df_rumc.text.apply(lambda text: "<PERSOON>" in text).sum() > 1200, f"Unexpected number of <PERSOON> tags in RUMC reports: {df_rumc.text.apply(lambda text: '<PERSOON>' in text).sum()}"
+    assert df_rumc.text.apply(lambda text: "<DATUM>" in text).sum() > 1200, f"Unexpected number of <DATUM> tags in RUMC reports: {df_rumc.text.apply(lambda text: '<DATUM>' in text).sum()}"
+    assert df_umcg.text.apply(lambda text: "<DATUM>" in text).sum() > 150, f"Unexpected number of <DATUM> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<DATUM>' in text).sum()}"
+    assert df_umcg.text.apply(lambda text: "<TIJD>" in text).sum() > 150, f"Unexpected number of <TIJD> tags in UMCG reports: {df_umcg.text.apply(lambda text: '<TIJD>' in text).sum()}"
+    assert df_avl.text.apply(lambda text: "<PERSOON>" in text).sum() > 150, f"Unexpected number of <PERSOON> tags in AVL reports: {df_avl.text.apply(lambda text: '<PERSOON>' in text).sum()}"
+    assert df_avl.text.apply(lambda text: "<DATUM>" in text).sum() > 100, f"Unexpected number of <DATUM> tags in AVL reports: {df_avl.text.apply(lambda text: '<DATUM>' in text).sum()}"
+    df = pd.concat((df_rumc[cols], df_umcg[cols], df_avl[cols]), ignore_index=True)
+    print(f"Have {len(df)} radiology reports ({num_patients(df)} patients) in total")
+
+    # prepare labels
+    df["label"] = df["label"].astype(float)
+    df = df.rename(columns={"label": "single_label_regression_target"})
+
+    # prepare for anonynimization
+    prepare_for_anon(df=df, output_dir=output_dir, task_name=task_name, tag_phi=False, apply_hips=True)
+
+
+def prepare_reports(
+    task_name: str,
+    output_dir: Path,
+    test_split_size: float = 0.3,
+):
+    # read anonynimized data
+    df = read_anon(output_dir / "anon" / task_name / "nlp-dataset.json")
+
+    # make test and cross-validation splits
+    df["text_parts"] = df.apply(lambda row: [row["center"], row["text"]], axis=1)
+    df = df.drop(columns=["center", "text"])
+    split_and_save_data(
+        df=df,
+        output_dir=output_dir,
+        task_name=task_name,
+        test_split_size=test_split_size,
+        recommended_truncation_side="right",
+    )
+
+
+if __name__ == "__main__":
+    # create the parser
+    parser = argparse.ArgumentParser(description="Script for preparing reports")
+    parser.add_argument("--task_name", type=str, default="Task021_psad_reg",
+                        help="Name of the task")
+    parser.add_argument("-i", "--input", type=Path, default=Path("/input"),
+                        help="Path to the input data")
+    parser.add_argument("-o", "--output", type=Path, default=Path("/output"),
+                        help="Folder to store the prepared reports in")
+    parser.add_argument("--test_split_size", type=float, default=0.3,
+                        help="Fraction of the dataset to use for testing")
+    args = parser.parse_args()
+
+    # run preprocessing
+    preprocess_reports(
+        task_name=args.task_name,
+        input_dir=args.input,
+        output_dir=args.output,
+    )
+    prepare_reports(
+        task_name=args.task_name,
+        output_dir=args.output,
+        test_split_size=args.test_split_size,
+    )

--- a/src/dragon_prep/federated/Task023_nodule_diameter_reg.py
+++ b/src/dragon_prep/federated/Task023_nodule_diameter_reg.py
@@ -1,0 +1,64 @@
+#  Copyright 2022 Diagnostic Image Analysis Group, Radboudumc, Nijmegen, The Netherlands
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import argparse
+from pathlib import Path
+
+from dragon_prep.Task023_nodule_diameter_reg import preprocess_reports
+from dragon_prep.utils import read_anon, split_and_save_data
+
+
+def prepare_reports(
+    task_name: str,
+    output_dir: Path,
+):
+    # read anonynimized data
+    df_dev = read_anon(output_dir / "anon" / task_name / "nlp-development-dataset.json")
+    df_test = read_anon(output_dir / "anon" / task_name / "nlp-test-dataset.json")
+
+    # make test and cross-validation splits
+    df_dev["text_parts"] = df_dev.apply(lambda row: [row["hospital"], row["text"]], axis=1)
+    df_dev = df_dev.drop(columns=["hospital", "text"])
+    df_test["text_parts"] = df_test.apply(lambda row: [row["hospital"], row["text"]], axis=1)
+    df_test = df_test.drop(columns=["hospital", "text"])
+    split_and_save_data(
+        df=df_dev,
+        df_test=df_test,
+        output_dir=output_dir,
+        task_name=task_name,
+        split_by="PatientID",
+    )
+
+
+if __name__ == "__main__":
+    # create the parser
+    parser = argparse.ArgumentParser(description="Script for preparing reports")
+    parser.add_argument("--task_name", type=str, default="Task023_nodule_diameter_reg",
+                        help="Name of the task")
+    parser.add_argument("-i", "--input", type=Path, default=Path("/input"),
+                        help="Path to the input data")
+    parser.add_argument("-o", "--output", type=Path, default=Path("/output"),
+                        help="Folder to store the prepared reports in")
+    args = parser.parse_args()
+
+    # run preprocessing
+    preprocess_reports(
+        task_name=args.task_name,
+        input_dir=args.input,
+        output_dir=args.output,
+    )
+    prepare_reports(
+        task_name=args.task_name,
+        output_dir=args.output,
+    )

--- a/src/dragon_prep/federated/Task024_recist_lesion_size_reg.py
+++ b/src/dragon_prep/federated/Task024_recist_lesion_size_reg.py
@@ -1,0 +1,101 @@
+#  Copyright 2022 Diagnostic Image Analysis Group, Radboudumc, Nijmegen, The Netherlands
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from dragon_prep.Task024_recist_lesion_size_reg import convert_lesion_size
+from dragon_prep.utils import prepare_for_anon, read_anon, split_and_save_data
+
+
+def preprocess_reports(
+    task_name: str,
+    input_dir: Path,
+    output_dir: Path,
+):
+    # read marksheets
+    df_jbz = pd.read_excel(input_dir / "JBZ_RECIST_cases_JB_MG.xlsx", dtype=str)
+    df_rumc = pd.read_excel(input_dir / "RadboudUMC_RECIST_cases_MG.xlsx", dtype=str)
+
+    # rename columns
+    df_jbz = df_jbz.rename(columns={f"tl{i}_size": f"l{i}_size" for i in range(1, 20)})
+    df_rumc = df_rumc.rename(columns={"anon_patientid": "PatientID", "anon_studyinstanceuid": "StudyInstanceUID"} | {f"L{i}_size": f"l{i}_size" for i in range(1, 7)})
+    df_rumc["text"] = df_rumc["raw_text"]
+
+    # add center
+    df_rumc["center"] = "RUMC"
+    df_jbz["center"] = "JBZ"
+
+    # merge datasets and select relevant columns
+    cols = ["PatientID", "text", "StudyInstanceUID", "center"] + [f"l{i}_size" for i in range(1, 6)]
+    df = pd.concat([df_jbz[cols], df_rumc[cols]], axis=0, ignore_index=True)
+    df["uid"] = df["StudyInstanceUID"]
+
+    # make label
+    df["multi_label_regression_target"] = df.apply(lambda row: [
+        convert_lesion_size(row[f"l{i}_size"]) for i in range(1, 5+1)
+        ], axis=1
+    )
+
+    # prepare for anonynimization
+    prepare_for_anon(df=df, output_dir=output_dir, task_name=task_name)
+
+
+def prepare_reports(
+    task_name: str,
+    output_dir: Path,
+    test_split_size: float = 0.3,
+):
+    # read anonynimized data
+    df = read_anon(output_dir / "anon" / task_name / "nlp-dataset.json")
+
+    # make test and cross-validation splits
+    df["text_parts"] = df.apply(lambda row: [row["center"], row["text"]], axis=1)
+    df = df.drop(columns=["center", "text"])
+    split_and_save_data(
+        df=df,
+        output_dir=output_dir,
+        task_name=task_name,
+        test_split_size=test_split_size,
+        split_by="PatientID",
+    )
+
+
+if __name__ == "__main__":
+    # create the parser
+    parser = argparse.ArgumentParser(description="Script for preparing reports")
+    parser.add_argument("--task_name", type=str, default="Task024_recist_lesion_size_reg",
+                        help="Name of the task")
+    parser.add_argument("-i", "--input", type=Path, default=Path("/input"),
+                        help="Path to the input data")
+    parser.add_argument("-o", "--output", type=Path, default=Path("/output"),
+                        help="Folder to store the prepared reports in")
+    parser.add_argument("--test_split_size", type=float, default=0.3,
+                        help="Fraction of the dataset to use for testing")
+    args = parser.parse_args()
+
+    # run preprocessing
+    preprocess_reports(
+        task_name=args.task_name,
+        input_dir=args.input,
+        output_dir=args.output,
+    )
+    prepare_reports(
+        task_name=args.task_name,
+        output_dir=args.output,
+        test_split_size=args.test_split_size,
+    )

--- a/src/dragon_prep/federated/Task025_anonymisation_ner.py
+++ b/src/dragon_prep/federated/Task025_anonymisation_ner.py
@@ -1,0 +1,204 @@
+#  Copyright 2022 Diagnostic Image Analysis Group, Radboudumc, Nijmegen, The Netherlands
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import argparse
+import hashlib
+import re
+from pathlib import Path
+
+import pandas as pd
+from tqdm import tqdm
+
+from dragon_prep.ner import doccano_to_bio_tags
+from dragon_prep.Task025_anonymisation_ner import (
+    combine_phi_labels, preprocess_reports_avl,
+    preprocess_reports_rumc_bcc_pathology,
+    preprocess_reports_rumc_lung_pathology,
+    preprocess_reports_rumc_prostate_biopsy_procedure,
+    preprocess_reports_rumc_prostate_pathology,
+    preprocess_reports_rumc_thorax_abdomen_ct)
+from dragon_prep.utils import (num_patients, prepare_for_anon, read_anon,
+                               split_and_save_data)
+
+try:
+    from report_anonymizer.model.anonymizer_functions import Anonymizer
+except ImportError:
+    print("Anonymizer not found, will not be able to run the full pipeline.")
+
+
+def preprocess_reports(
+    task_name: str,
+    input_dir: Path,
+    output_dir: Path,
+):
+    # validate input
+    cols = ["uid", "PatientID", "text", "label"]
+
+    # read reports and labels from RUMC
+    df_rumc_ct = preprocess_reports_rumc_thorax_abdomen_ct(
+        input_dir=input_dir / "rumc/anonymisation/ct-thorax-abdomen",
+    )
+    df_rumc_prostate_pathology = preprocess_reports_rumc_prostate_pathology(
+        input_dir=input_dir / "rumc/anonymisation/pathology-prostate",
+    )
+    df_rumc_bcc = preprocess_reports_rumc_bcc_pathology(
+        input_dir=input_dir / "rumc/bcc",
+    )
+    df_rumc_prostate_biopsy = preprocess_reports_rumc_prostate_biopsy_procedure(
+        input_dir=input_dir / "rumc/prostate-biopsy",
+    )
+    df_rumc_lung_pathology = preprocess_reports_rumc_lung_pathology(
+        input_dir=input_dir / "rumc/pathology-lung",
+    )
+    df_rumc = pd.concat([
+        df_rumc_ct[cols],
+        df_rumc_prostate_pathology[cols],
+        df_rumc_bcc[cols],
+        df_rumc_prostate_biopsy[cols],
+        df_rumc_lung_pathology[cols],
+    ], ignore_index=True)
+    print(f"Have {len(df_rumc)} reports ({num_patients(df_rumc)} patients) for RUMC after combining datasets")
+    df_rumc["center"] = "RUMC"
+
+    # read reports and labels from AvL
+    df_avl = preprocess_reports_avl(
+        input_dir=input_dir / "avl/prostate",
+    )
+    df_avl["center"] = "AVL"
+
+    # combine the datasets
+    cols = cols + ["center"]
+    df = pd.concat([df_rumc[cols], df_avl[cols]], ignore_index=True)
+
+    print(f"Have {len(df)} reports ({num_patients(df)} patients) after combining datasets")
+
+    # combine equivalent labels
+    df["label"] = df.label.apply(lambda x: [[
+        int(start), int(end), label.replace("<NAAM>", "<PERSOON>").replace("<TNUMMER>", "<RAPPORT_ID>")
+    ] for start, end, label in x])
+
+    # print label statistics
+    all_labels = [label[2] for labels in df.label for label in labels]
+    print(f"Have {len(all_labels)} labels in total, with {len(set(all_labels))} unique labels")
+    print(pd.Series(all_labels).value_counts())
+
+    # perform anonynimization
+    df = df[cols]
+    df_paths = prepare_for_anon(df=df, output_dir=output_dir, task_name=task_name, tag_phi=False, apply_hips=False)
+    anonymizer = Anonymizer()
+    for paths in df_paths:
+        # read the reports
+        df = pd.read_json(paths["path_for_anon"])
+        for i, row in tqdm(df.iterrows(), total=len(df)):
+            report = row["text"]
+
+            # apply PHI annotations
+            phi_labels_orig = row["meta"]["label"]
+            sorted_labels = sorted(phi_labels_orig, key=lambda x: x[0], reverse=True)
+            phi_labels_tags = phi_labels_orig
+            for start_idx, end_idx, tag in sorted_labels:
+                report = report[:start_idx] + tag + report[end_idx:]
+                shift = len(tag) - (end_idx - start_idx)
+                phi_labels_tags = [
+                    (start + (shift if start > start_idx else 0), end + (shift if start >= start_idx else 0), label)
+                    for (start, end, label) in phi_labels_tags
+                ]
+
+            # verify the PHI annotations and shifted labels
+            for start_idx, end_idx, tag in phi_labels_tags:
+                assert report[start_idx:end_idx] == tag, f"Expected '{tag}' at {start_idx}:{end_idx} in '{report[start_idx-10:start_idx]}|{report[start_idx:end_idx]}|{report[end_idx:end_idx+10]}'"
+
+            # apply HIPS
+            md5_hash = hashlib.md5(report.encode())
+            seed = int(md5_hash.hexdigest(), 16) % 2 ** 32
+            report_anon, phi_labels_anon = anonymizer.HideInPlainSight.apply_hips(report=report, seed=seed, ner_labels=phi_labels_tags)
+
+            # save
+            df.at[i, "text"] = report_anon
+            row["meta"]["label"] = phi_labels_anon
+
+        # sanity check
+        for i, row in df.iterrows():
+            report = row["text"]
+            remaining_phi_tags = re.findall(r"<[a-zA-Z0-9\.\-\_]{1,50}>", report)
+            for res in remaining_phi_tags:
+                if res not in ["<st0>", "</st0>", "<st1>", "</st1>", "<st2>", "</st2>", "<beschermd>", "</beschermd>"]:
+                    raise ValueError(f"Found remaining PHI tag: {res} in '{report}'")
+
+        # save the reports
+        df.to_json(paths["path_anon"], orient="records", indent=2)
+
+
+def prepare_reports(
+    task_name: str,
+    output_dir: Path,
+    test_split_size: float = 0.3,
+):
+    # read anonynimized data
+    df = read_anon(output_dir / "anon" / task_name / "nlp-dataset.json")
+
+    # merge particular labels (after anonymisation using HIPS)
+    df["label"] = df.label.apply(lambda x: [
+        [int(start), int(end), combine_phi_labels(label)]
+        for start, end, label in x
+    ])
+
+    # print label statistics
+    all_labels = [label[2] for labels in df.label for label in labels]
+    print(f"Have {len(all_labels)} labels in total, with {len(set(all_labels))} unique labels")
+    print(pd.Series(all_labels).value_counts())
+
+    # tokenize reports
+    data = df.to_dict(orient="records")
+    data = doccano_to_bio_tags(data)
+
+    # restructure data
+    df = pd.DataFrame(data)
+    df.rename(columns={"labels": "named_entity_recognition_target", "text": "text_parts"}, inplace=True)
+
+    # make test and cross-validation splits
+    df["text_parts"] = df.apply(lambda row: [row["center"]] + list(row["text_parts"]), axis=1)
+    split_and_save_data(
+        df=df,
+        output_dir=output_dir,
+        task_name=task_name,
+        test_split_size=test_split_size,
+        split_by="PatientID",
+    )
+
+
+if __name__ == "__main__":
+    # create the parser
+    parser = argparse.ArgumentParser(description="Script for preparing reports")
+    parser.add_argument("--task_name", type=str, default="Task025_anonymisation_ner",
+                        help="Name of the task")
+    parser.add_argument("-i", "--input", type=Path, default=Path("/input"),
+                        help="Path to the input data")
+    parser.add_argument("-o", "--output", type=Path, default=Path("/output"),
+                        help="Folder to store the prepared reports in")
+    parser.add_argument("--test_split_size", type=float, default=0.3,
+                        help="Fraction of the dataset to use for testing")
+    args = parser.parse_args()
+
+    # run preprocessing
+    preprocess_reports(
+        task_name=args.task_name,
+        input_dir=args.input,
+        output_dir=args.output,
+    )
+    prepare_reports(
+        task_name=args.task_name,
+        output_dir=args.output,
+        test_split_size=args.test_split_size,
+    )

--- a/src/dragon_prep/federated/make_debug_splits.py
+++ b/src/dragon_prep/federated/make_debug_splits.py
@@ -1,0 +1,115 @@
+#  Copyright 2022 Diagnostic Image Analysis Group, Radboudumc, Nijmegen, The Netherlands
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import argparse
+import json
+from pathlib import Path
+
+import pandas as pd
+from tqdm import tqdm
+
+
+def main(
+    federated_data_dir: Path,
+    reference_data_dir: Path,
+    debug_input_dir: Path,
+    debug_test_dir: Path,
+):
+    for input_task_dir in tqdm(federated_data_dir.glob("*-fold0"), desc="Making debug splits"):
+        if not input_task_dir.is_dir():
+            continue
+
+        # create output task dir
+        output_task_dir = debug_input_dir / input_task_dir.name
+        output_task_dir.mkdir(exist_ok=True, parents=True)
+        task_name = input_task_dir.name.split("-fold0")[0]
+
+        # read data
+        data = []
+        with open(input_task_dir / "nlp-training-dataset.json") as f:
+            data += json.load(f)
+        with open(input_task_dir / "nlp-validation-dataset.json") as f:
+            data += json.load(f)
+        with open(input_task_dir / "nlp-task-configuration.json") as f:
+            task_config = json.load(f)
+        task_config["jobid"] += 2000
+        df_dev = pd.DataFrame(data)
+
+        # read reference data
+        reference_data = []
+        with open(reference_data_dir / input_task_dir.name / "nlp-training-dataset.json") as f:
+            reference_data += json.load(f)
+        with open(reference_data_dir / input_task_dir.name / "nlp-validation-dataset.json") as f:
+            reference_data += json.load(f)
+        reference_data = pd.DataFrame(reference_data)
+
+        # extract center
+        df_dev["center"] = df_dev["text_parts"].apply(lambda parts: parts[0])
+        if len(df_dev.iloc[0]["text_parts"]) == 2:
+            df_dev["text"] = df_dev["text_parts"].apply(lambda parts: parts[1])
+            df_dev = df_dev.drop(columns=["text_parts"])
+            task_config["input_name"] = "text"
+        else:
+            df_dev["text_parts"] = df_dev["text_parts"].apply(lambda parts: parts[1:])
+
+        # verify splits are correct
+        for col in df_dev.columns:
+            if col == "center":
+                continue
+            mask = (df_dev[col] != reference_data[col])
+            if mask.mean() > 0.05:
+                print(f"Warning: Column {col} differs for {mask.mean():.1%} of entries")
+            if mask.mean() > 0.1:
+                raise ValueError(f"Column {col} differs for {mask.mean():.1%} of entries")
+
+        # copy reports
+        df_dev[task_config["input_name"]] = reference_data[task_config["input_name"]]
+        df_dev[task_config["label_name"]] = reference_data[task_config["label_name"]]
+
+        # split data
+        df_test = df_dev.sample(frac=0.3, random_state=42)
+        df_dev = df_dev.drop(df_test.index)
+        df_train = df_dev.sample(frac=0.8, random_state=42)
+        df_val = df_dev.drop(df_train.index)
+
+        # write data
+        df_train.to_json(output_task_dir / "nlp-training-dataset.json", orient="records", indent=2)
+        df_val.to_json(output_task_dir / "nlp-validation-dataset.json", orient="records", indent=2)
+        df_test[["uid", "center", task_config["input_name"]]].to_json(output_task_dir / "nlp-test-dataset.json", orient="records", indent=2)
+        df_test.to_json(debug_test_dir / f"{task_name}.json", orient="records", indent=2)
+        with open(output_task_dir / "nlp-task-configuration.json", "w") as f:
+            json.dump(task_config, f, indent=2)
+
+
+if __name__ == "__main__":
+    # create the parser
+    parser = argparse.ArgumentParser(description="Script for preparing reports")
+
+    parser.add_argument("-i", "--federated-algorithm-input", type=Path, default=Path("/input/federated/algorithm-input"),
+                        help="Path to the input data")
+    parser.add_argument("-r", "--original-algorithm-input", type=Path, default=Path("/input/algorithm-input"),
+                        help="Path to the reference input data")
+    parser.add_argument("-o", "--debug-input-dir", type=Path, default=Path("/output/federated/debug-input"),
+                        help="Folder to store the prepared reports in")
+    parser.add_argument("-t", "--debug-test-dir", type=Path, default=Path("/output/federated/debug-test-set"),
+                        help="Folder to store the prepared reports in")
+    args = parser.parse_args()
+
+    # run preprocessing
+    main(
+        federated_data_dir=args.federated_algorithm_input,
+        reference_data_dir=args.original_algorithm_input,
+        debug_input_dir=args.debug_input_dir,
+        debug_test_dir=args.debug_test_dir,
+    )

--- a/src/dragon_prep/federated/make_synthetic_splits.py
+++ b/src/dragon_prep/federated/make_synthetic_splits.py
@@ -1,0 +1,93 @@
+#  Copyright 2022 Diagnostic Image Analysis Group, Radboudumc, Nijmegen, The Netherlands
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from tqdm import tqdm
+
+
+def main(
+    input_dir: Path,
+    output_dir: Path,
+    seed: int = 42,
+):
+    algorithm_input_dir = input_dir / "algorithm-input"
+    test_labeled_dir = input_dir / "test-set"
+    for input_task_dir in tqdm(algorithm_input_dir.glob("Task*_Example_*-fold0"), desc="Preparing synthetic data"):
+        if not input_task_dir.is_dir():
+            continue
+
+        # create output task dir
+        output_task_dir = output_dir / "algorithm-input" / input_task_dir.name
+        debug_test_dir = output_dir / "test-set"
+        task_name = input_task_dir.name.split("-fold0")[0]
+
+        # read data
+        with open(input_task_dir / "nlp-training-dataset.json") as f:
+            df_train = pd.DataFrame(json.load(f))
+        with open(input_task_dir / "nlp-validation-dataset.json") as f:
+            df_val = pd.DataFrame(json.load(f))
+        with open(input_task_dir / "nlp-test-dataset.json") as f:
+            df_test = pd.DataFrame(json.load(f))
+        with open(test_labeled_dir / f"{task_name}.json") as f:
+            df_test_labeled = pd.DataFrame(json.load(f))
+        with open(input_task_dir / "nlp-task-configuration.json") as f:
+            task_config = json.load(f)
+
+        if task_config["label_name"] not in [
+            "single_label_binary_classification_target",
+            "multi_label_binary_classification_target",
+            "multi_label_regression_target",
+            "named_entity_recognition_target",
+        ]:
+            print(f"Skipping task {task_name} with label {task_config['label_name']}")
+            continue
+
+        # add center
+        n_centers = max(2, len(df_train) // 100)
+        np.random.seed(seed)
+        for df in [df_train, df_val, df_test]:
+            tqdm.write(f"Adding {n_centers} centers to {len(df)} entries for task {task_name}")
+            df["center"] = np.random.randint(0, n_centers, len(df)).astype(str)
+
+        df_test_labeled["center"] = df_test["center"]
+
+        # write data
+        output_task_dir.mkdir(exist_ok=True, parents=True)
+        df_train.to_json(output_task_dir / "nlp-training-dataset.json", orient="records", indent=2)
+        df_val.to_json(output_task_dir / "nlp-validation-dataset.json", orient="records", indent=2)
+        df_test[["uid", "center", task_config["input_name"]]].to_json(output_task_dir / "nlp-test-dataset.json", orient="records", indent=2)
+        df_test.to_json(debug_test_dir / f"{task_name}.json", orient="records", indent=2)
+        with open(output_task_dir / "nlp-task-configuration.json", "w") as f:
+            json.dump(task_config, f, indent=2)
+
+
+if __name__ == "__main__":
+    # create the parser
+    parser = argparse.ArgumentParser(description="Script for preparing reports")
+    parser.add_argument("-i", "--input", type=Path, default=Path("/input"),
+                        help="Path to the input data")
+    parser.add_argument("-o", "--output", type=Path, default=Path("/output"),
+                        help="Folder to store the prepared reports in")
+    args = parser.parse_args()
+
+    # run preprocessing
+    main(
+        input_dir=args.input,
+        output_dir=args.output,
+    )

--- a/src/dragon_prep/federated/make_synthetic_splits.py
+++ b/src/dragon_prep/federated/make_synthetic_splits.py
@@ -72,7 +72,7 @@ def main(
         df_train.to_json(output_task_dir / "nlp-training-dataset.json", orient="records", indent=2)
         df_val.to_json(output_task_dir / "nlp-validation-dataset.json", orient="records", indent=2)
         df_test[["uid", "center", task_config["input_name"]]].to_json(output_task_dir / "nlp-test-dataset.json", orient="records", indent=2)
-        df_test.to_json(debug_test_dir / f"{task_name}.json", orient="records", indent=2)
+        df_test_labeled.to_json(debug_test_dir / f"{task_name}.json", orient="records", indent=2)
         with open(output_task_dir / "nlp-task-configuration.json", "w") as f:
             json.dump(task_config, f, indent=2)
 

--- a/src/dragon_prep/federated/make_test_splits.py
+++ b/src/dragon_prep/federated/make_test_splits.py
@@ -1,0 +1,117 @@
+#  Copyright 2022 Diagnostic Image Analysis Group, Radboudumc, Nijmegen, The Netherlands
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import argparse
+import json
+from pathlib import Path
+
+import pandas as pd
+from tqdm import tqdm
+
+
+def main(
+    federated_data_dir: Path,
+    reference_data_dir: Path,
+    federated_test_dir: Path,
+    reference_test_dir: Path,
+):
+    files = sorted(federated_data_dir.glob("*-fold*"))
+    for input_task_dir in tqdm(files, desc="Making debug splits"):
+        if not input_task_dir.is_dir():
+            continue
+
+        task_name = input_task_dir.name.split("-fold")[0]
+
+        # read data
+        with open(input_task_dir / "nlp-training-dataset.json") as f:
+            df_train = pd.DataFrame(json.load(f))
+        with open(input_task_dir / "nlp-validation-dataset.json") as f:
+            df_val = pd.DataFrame(json.load(f))
+        with open(input_task_dir / "nlp-test-dataset.json") as f:
+            df_test = pd.DataFrame(json.load(f))
+        with open(federated_test_dir / f"{task_name}.json") as f:
+            df_test_labeled = pd.DataFrame(json.load(f))
+        with open(input_task_dir / "nlp-task-configuration.json") as f:
+            task_config = json.load(f)
+
+        # read reference data
+        with open(reference_data_dir / input_task_dir.name / "nlp-training-dataset.json") as f:
+            df_train_reference = pd.DataFrame(json.load(f))
+        with open(reference_data_dir / input_task_dir.name / "nlp-validation-dataset.json") as f:
+            df_validation_reference = pd.DataFrame(json.load(f))
+        with open(reference_data_dir / input_task_dir.name / "nlp-test-dataset.json") as f:
+            df_test_reference = pd.DataFrame(json.load(f))
+        with open(reference_test_dir / f"{task_name}.json") as f:
+            df_test_labelled_reference = pd.DataFrame(json.load(f))
+
+        # extract center
+        for df, df_ref in [
+            (df_train, df_train_reference),
+            (df_val, df_validation_reference),
+            (df_test, df_test_reference),
+            (df_test_labeled, df_test_labelled_reference),
+        ]:
+            df["center"] = df["text_parts"].apply(lambda parts: parts[0])
+            if len(df.iloc[0]["text_parts"]) == 2:
+                df["text"] = df["text_parts"].apply(lambda parts: parts[1])
+                df.drop(columns=["text_parts"], inplace=True)
+                task_config["input_name"] = "text"
+            else:
+                df["text_parts"] = df["text_parts"].apply(lambda parts: parts[1:])
+
+            # verify splits are correct
+            for col in df.columns:
+                if col == "center":
+                    continue
+                mask = (df[col] != df_ref[col])
+                if mask.mean() > 0.05:
+                    print(f"Warning: Column {col} differs for {mask.mean():.1%} of entries")
+                if mask.mean() > 0.1:
+                    raise ValueError(f"Column {col} differs for {mask.mean():.1%} of entries")
+
+            # copy reports
+            df[task_config["input_name"]] = df_ref[task_config["input_name"]]
+            if task_config["label_name"] in df.columns:
+                df[task_config["label_name"]] = df_ref[task_config["label_name"]]
+
+        # write data
+        df_train.to_json(input_task_dir / "nlp-training-dataset.json", orient="records", indent=2)
+        df_val.to_json(input_task_dir / "nlp-validation-dataset.json", orient="records", indent=2)
+        df_test.to_json(input_task_dir / "nlp-test-dataset.json", orient="records", indent=2)
+        if "-fold4" in input_task_dir.name:
+            df_test_labeled.to_json(federated_test_dir / f"{task_name}.json", orient="records", indent=2)
+        with open(input_task_dir / "nlp-task-configuration.json", "w") as f:
+            json.dump(task_config, f, indent=2)
+
+
+if __name__ == "__main__":
+    # create the parser
+    parser = argparse.ArgumentParser(description="Script for preparing reports")
+    parser.add_argument("-i", "--federated-algorithm-input", type=Path, default=Path("/input/federated/algorithm-input"),
+                        help="Path to the input data")
+    parser.add_argument("-r", "--original-algorithm-input", type=Path, default=Path("/input/algorithm-input"),
+                        help="Path to the reference input data")
+    parser.add_argument("-t", "--federated-test-dir", type=Path, default=Path("/input/federated/test-set"),
+                        help="Path to the test data")
+    parser.add_argument("-d", "--original-test-dir", type=Path, default=Path("/input/test-set"),
+                        help="Path to the reference test data")
+    args = parser.parse_args()
+
+    # run preprocessing
+    main(
+        federated_data_dir=args.federated_algorithm_input,
+        reference_data_dir=args.original_algorithm_input,
+        federated_test_dir=args.federated_test_dir,
+        reference_test_dir=args.original_test_dir,
+    )

--- a/src/dragon_prep/federated/upload_debug_datasets.py
+++ b/src/dragon_prep/federated/upload_debug_datasets.py
@@ -1,0 +1,88 @@
+import os
+from pathlib import Path
+from typing import Any
+
+import gcapi
+from tqdm import tqdm
+
+"""
+Upload archive to Grand Challenge using the gcapi
+"""
+
+# paths
+archive_dir = Path("/Users/joeranbosma/repos/dragon_data/preprocessed/federated/debug-input")
+token = os.getenv("GC_TOKEN")
+
+# name of the archive
+archive_slug = "dragon-validation-federated-dataset"
+
+# initialise client
+client = gcapi.Client(token=token)
+
+# select archive
+archive = client.archives.detail(slug=archive_slug)
+archive_url = archive["api_url"]
+
+fold = 0
+dataset_names = [
+    # First, the tasks most likely to time out or fail:
+    "Task023",
+    "Task024",
+    "Task025",
+    # Then the rest:
+    "Task002",
+    "Task005",
+    "Task007",
+    "Task010",
+    "Task011",
+    "Task016",
+    "Task019",
+    "Task020",
+    "Task021",
+]
+datasets = [archive_dir.glob(f"{dataset}*-fold{fold}").__next__() for dataset in dataset_names]
+
+if len(datasets) != 12:
+    raise Exception(f"Unexpected number of datasets, found {len(datasets)}: {datasets}.")
+for path in datasets:
+    if not path.exists():
+        raise Exception(f"Path does not exist: {path}.")
+print(f"Uploading: {datasets}.")
+
+# create archive items
+sessions = {}
+
+for dataset_path in tqdm(datasets, desc="Creating archive items"):
+    session = client.archive_items.create(
+        values=[],
+        archive=archive_url,
+    )
+
+    sessions[dataset_path] = session
+
+# upload training resources to each archive item
+sub_sessions: dict[Path, dict[str, Any]] = {}
+
+for dataset_path, session in tqdm(zip(datasets, sessions.values()), desc="Uploading archive items"):
+    # upload elements to archive item
+    for interface_name in [
+        "nlp-training-dataset",
+        "nlp-validation-dataset",
+        "nlp-test-dataset",
+        "nlp-task-configuration",
+    ]:
+        # construct path to file
+        path = dataset_path / f"{interface_name}.json"
+        assert path.exists()
+
+        print(f"Uploading {path}..")
+        sub_session = client.update_archive_item(
+            archive_item_pk=session['pk'],
+            values={
+                interface_name: [path],
+            },
+        )
+
+        if dataset_path not in sub_sessions:
+            sub_sessions[dataset_path] = {}
+        sub_sessions[dataset_path][interface_name] = sub_session

--- a/src/dragon_prep/federated/upload_example_datasets.py
+++ b/src/dragon_prep/federated/upload_example_datasets.py
@@ -1,0 +1,68 @@
+import os
+from pathlib import Path
+from typing import Any
+
+import gcapi
+from tqdm import tqdm
+
+"""
+Upload archive to Grand Challenge using the gcapi
+"""
+
+# paths
+archive_dir = Path("/Users/joeranbosma/repos/dragon_data/preprocessed/federated/algorithm-input")
+token = os.getenv("GC_TOKEN")
+
+# name of the archive
+archive_slug = "dragon-synthetic-federated-dataset"
+
+datasets = sorted(list(archive_dir.glob("Task1*_Example_*-fold0")), reverse=True)
+
+if len(datasets) != 4:
+    raise Exception(f"Unexpected number of example datasets, found {len(datasets)}: {datasets}.")
+print(f"Uploading: {datasets}.")
+
+# initialise client
+client = gcapi.Client(token=token)
+
+# select archive
+archive = client.archives.detail(slug=archive_slug)
+archive_url = archive["api_url"]
+
+# create archive items
+sessions = {}
+
+for dataset_path in tqdm(datasets, desc="Creating archive items"):
+    session = client.archive_items.create(
+        values=[],
+        archive=archive_url,
+    )
+
+    sessions[dataset_path] = session
+
+# upload training resources to each archive item
+sub_sessions: dict[Path, dict[str, Any]] = {}
+
+for dataset_path, session in tqdm(zip(datasets, sessions.values()), desc="Uploading archive items"):
+    # upload elements to archive item
+    for interface_name in [
+        "nlp-training-dataset",
+        "nlp-validation-dataset",
+        "nlp-test-dataset",
+        "nlp-task-configuration",
+    ]:
+        # construct path to file
+        path = dataset_path / f"{interface_name}.json"
+        assert path.exists()
+
+        print(f"Uploading {path}..")
+        sub_session = client.update_archive_item(
+            archive_item_pk=session['pk'],
+            values={
+                interface_name: [path],
+            },
+        )
+
+        if dataset_path not in sub_sessions:
+            sub_sessions[dataset_path] = {}
+        sub_sessions[dataset_path][interface_name] = sub_session

--- a/src/dragon_prep/federated/upload_test_datasets.py
+++ b/src/dragon_prep/federated/upload_test_datasets.py
@@ -1,0 +1,88 @@
+import os
+from pathlib import Path
+from typing import Any
+
+import gcapi
+from tqdm import tqdm
+
+"""
+Upload archive to Grand Challenge using the gcapi
+"""
+
+# paths
+archive_dir = Path("/Users/joeranbosma/repos/dragon_data/preprocessed/federated/algorithm-input")
+token = os.getenv("GC_TOKEN")
+
+# name of the archive
+archive_slug = "dragon-2-dataset"
+
+# initialise client
+client = gcapi.Client(token=token)
+
+# select archive
+archive = client.archives.detail(slug=archive_slug)
+archive_url = archive["api_url"]
+
+for fold in range(5):
+    dataset_names = [
+        # First, the tasks most likely to time out or fail:
+        "Task023",
+        "Task024",
+        "Task025",
+        # Then the rest:
+        "Task002",
+        "Task005",
+        "Task007",
+        "Task010",
+        "Task011",
+        "Task016",
+        "Task019",
+        "Task020",
+        "Task021",
+    ]
+    datasets = [archive_dir.glob(f"{dataset}*-fold{fold}").__next__() for dataset in dataset_names]
+
+    if len(datasets) != 12:
+        raise Exception(f"Unexpected number of datasets, found {len(datasets)}: {datasets}.")
+    for path in datasets:
+        if not path.exists():
+            raise Exception(f"Path does not exist: {path}.")
+    print(f"Uploading: {datasets}.")
+
+    # create archive items
+    sessions = {}
+
+    for dataset_path in tqdm(datasets, desc="Creating archive items"):
+        session = client.archive_items.create(
+            values=[],
+            archive=archive_url,
+        )
+
+        sessions[dataset_path] = session
+
+    # upload training resources to each archive item
+    sub_sessions: dict[Path, dict[str, Any]] = {}
+
+    for dataset_path, session in tqdm(zip(datasets, sessions.values()), desc="Uploading archive items"):
+        # upload elements to archive item
+        for interface_name in [
+            "nlp-training-dataset",
+            "nlp-validation-dataset",
+            "nlp-test-dataset",
+            "nlp-task-configuration",
+        ]:
+            # construct path to file
+            path = dataset_path / f"{interface_name}.json"
+            assert path.exists()
+
+            print(f"Uploading {path}..")
+            sub_session = client.update_archive_item(
+                archive_item_pk=session['pk'],
+                values={
+                    interface_name: [path],
+                },
+            )
+
+            if dataset_path not in sub_sessions:
+                sub_sessions[dataset_path] = {}
+            sub_sessions[dataset_path][interface_name] = sub_session

--- a/src/dragon_prep/ner.py
+++ b/src/dragon_prep/ner.py
@@ -75,7 +75,7 @@ def ner_tokenizer() -> Tokenizer:
     vocab = spacy.vocab.Vocab()
 
     # Add custom prefixes and suffixes for splitting text into tokens
-    split_chars = r'[:;,_\-\.\/\\\+\(\)~<>*]'
+    split_chars = r'[:;,_\-\.\/\\\+\(\)~<>*"\?]'
     prefixes = Dutch.Defaults.prefixes + [split_chars]
     suffixes = [p for p in Dutch.Defaults.suffixes if p != r'\.\.+'] + [split_chars]
     infixes = [p for p in Dutch.Defaults.infixes if p != r'\.\.+'] + [

--- a/src/dragon_prep/stats.py
+++ b/src/dragon_prep/stats.py
@@ -64,7 +64,7 @@ def main(
         # plot distribution of report lengths
         f, ax = plt.subplots(figsize=(10, 2.5))
         sns.histplot(lengths, bins=31, ax=ax)
-        ax.set_title(task_name.replace("_clf", "").replace("_reg", "").replace("_ner", "").replace("_", " "))
+        # ax.set_title(task_name.replace("_clf", "").replace("_reg", "").replace("_ner", "").replace("_", " "))
         ax.set_xlabel(f"Report length (tokens, {model_name} tokenizer)")
         ax.set_ylabel("Number of reports")
         f.tight_layout()

--- a/src/dragon_prep/upload_debug_datasets_per_task.py
+++ b/src/dragon_prep/upload_debug_datasets_per_task.py
@@ -1,0 +1,95 @@
+import os
+from pathlib import Path
+from typing import Any
+
+import gcapi
+from tqdm import tqdm
+
+"""
+Upload archive to Grand Challenge using the gcapi
+"""
+
+# paths
+archive_dir = Path("/Users/joeranbosma/repos/dragon_data/preprocessed/debug-input")
+token = os.getenv("GC_TOKEN")
+
+# initialise client
+client = gcapi.Client(token=token)
+
+fold = 0
+config = [
+    # First, the tasks most likely to time out or fail:
+    ("Task014", "debug-dragon-task-014"),  # most samples = most likely to time out
+    ("Task028", "debug-dragon-task-028"),  # most difficult = most likely to fail
+    # Then each of the remaining task types:
+    ("Task001", "debug-dragon-task-001"),
+    ("Task009", "debug-dragon-task-009"),
+    ("Task015", "debug-dragon-task-015"),
+    ("Task018", "debug-dragon-task-018"),
+    ("Task023", "debug-dragon-task-023"),
+    ("Task024", "debug-dragon-task-024"),
+    ("Task025", "debug-dragon-task-025"),
+    # Then the rest:
+    ("Task002", "debug-dragon-task-002"),
+    ("Task003", "debug-dragon-task-003"),
+    ("Task004", "debug-dragon-task-004"),
+    ("Task005", "debug-dragon-task-005"),
+    ("Task006", "debug-dragon-task-006"),
+    ("Task007", "debug-dragon-task-007"),
+    ("Task008", "debug-dragon-task-008"),
+    ("Task010", "debug-dragon-task-010"),
+    ("Task011", "debug-dragon-task-011"),
+    ("Task012", "debug-dragon-task-012"),
+    ("Task013", "debug-dragon-task-013"),
+    ("Task016", "debug-dragon-task-016"),
+    ("Task017", "debug-dragon-task-017"),
+    ("Task019", "debug-dragon-task-019"),
+    ("Task020", "debug-dragon-task-020"),
+    ("Task021", "debug-dragon-task-021"),
+    ("Task022", "debug-dragon-task-022"),
+    ("Task026", "debug-dragon-task-026"),
+    ("Task027", "debug-dragon-task-027"),
+]
+
+sessions = {}
+for dataset_name, archive_slug in tqdm(config):
+    # select archive
+    archive = client.archives.detail(slug=archive_slug)
+    archive_url = archive["api_url"]
+
+    print(f"Creating item for: {dataset_name}.")
+
+    # create archive item
+    session = client.archive_items.create(
+        values=[],
+        archive=archive_url,
+    )
+
+    sessions[dataset_name] = session
+
+    # upload training resources
+    sub_sessions: dict[Path, dict[str, Any]] = {}
+
+    # upload elements to archive item
+    dataset_dir = archive_dir.glob(f"{dataset_name}*-fold{fold}").__next__()
+    for interface_name in [
+        "nlp-training-dataset",
+        "nlp-validation-dataset",
+        "nlp-test-dataset",
+        "nlp-task-configuration",
+    ]:
+        # construct path to file
+        path = dataset_dir / f"{interface_name}.json"
+        assert path.exists()
+
+        print(f"Uploading {path}..")
+        sub_session = client.update_archive_item(
+            archive_item_pk=session['pk'],
+            values={
+                interface_name: [path],
+            },
+        )
+
+        if dataset_dir not in sub_sessions:
+            sub_sessions[dataset_dir] = {}
+        sub_sessions[dataset_dir][interface_name] = sub_session

--- a/src/dragon_prep/upload_test_one_run_datasets.py
+++ b/src/dragon_prep/upload_test_one_run_datasets.py
@@ -1,0 +1,108 @@
+import os
+from pathlib import Path
+from typing import Any
+
+import gcapi
+from tqdm import tqdm
+
+"""
+Upload archive to Grand Challenge using the gcapi
+"""
+
+# paths
+archive_dir = Path("/Users/joeranbosma/repos/dragon_data/preprocessed/algorithm-input")
+token = os.getenv("GC_TOKEN")
+
+# name of the archive
+archive_slug = "dragon-3-dataset"
+
+# initialise client
+client = gcapi.Client(token=token)
+
+# select archive
+archive = client.archives.detail(slug=archive_slug)
+archive_url = archive["api_url"]
+
+for fold in range(1):
+    dataset_names = [
+        # First, the tasks most likely to time out or fail:
+        "Task014",  # most samples = most likely to time out
+        "Task028",  # most difficult = most likely to fail
+        # Then each of the remaining task types:
+        "Task001",
+        "Task009",
+        "Task015",
+        "Task018",
+        "Task023",
+        "Task024",
+        "Task025",
+        # Then the rest:
+        "Task002",
+        "Task003",
+        "Task004",
+        "Task005",
+        "Task006",
+        "Task007",
+        "Task008",
+        "Task010",
+        "Task011",
+        "Task012",
+        "Task013",
+        "Task016",
+        "Task017",
+        "Task019",
+        "Task020",
+        "Task021",
+        "Task022",
+        "Task026",
+        "Task027",
+    ]
+    datasets = [archive_dir.glob(f"{dataset}*-fold{fold}").__next__() for dataset in dataset_names]
+
+    if len(datasets) != 28:
+        raise Exception(f"Expected 28 datasets, found {len(datasets)}: {datasets}.")
+    for path in datasets:
+        if not path.exists():
+            raise Exception(f"Path does not exist: {path}.")
+    print(f"Uploading: {datasets}.")
+
+    # create archive items
+    sessions = {}
+
+    for dataset_path in tqdm(datasets, desc="Creating archive items"):
+        session = client.archive_items.create(
+            values=[],
+            archive=archive_url,
+        )
+
+        sessions[dataset_path] = session
+
+    # upload training resources to each archive item
+    sub_sessions: dict[Path, dict[str, Any]] = {}
+
+    for dataset_path, session in tqdm(zip(datasets, sessions.values()), desc="Uploading archive items"):
+        # upload elements to archive item
+        for interface_name in [
+            "nlp-training-dataset",
+            "nlp-validation-dataset",
+            "nlp-test-dataset",
+            "nlp-task-configuration",
+        ]:
+            # construct path to file
+            path = dataset_path / f"{interface_name}.json"
+            assert path.exists()
+
+            print(f"Uploading {path}..")
+            try:
+                sub_session = client.update_archive_item(
+                    archive_item_pk=session['pk'],
+                    values={
+                        interface_name: [path],
+                    },
+                )
+
+                if dataset_path not in sub_sessions:
+                    sub_sessions[dataset_path] = {}
+                sub_sessions[dataset_path][interface_name] = sub_session
+            except Exception as e:
+                print(f"Failed to upload {path}: {e}")

--- a/src/dragon_prep/utils.py
+++ b/src/dragon_prep/utils.py
@@ -43,6 +43,7 @@ TARGET_COLUMN_NAMES = [
     "single_label_binary_classification_target",
     "multi_label_binary_classification_target",
     "multi_label_named_entity_recognition_target",
+    "text_target",
     "custom_target",
 ]
 
@@ -307,6 +308,7 @@ def split_and_save_data(
             - "multi_label_multi_class_classification_target": must be an array of strings for each case.
             - "single_label_binary_classification_target": must be an int for each case.
             - "multi_label_binary_classification_target": must be an array of ints (each either 0 or 1) for each case.
+            - "text_target": must be a string for each case.
             - "custom_target": custom target column (experimental).
         task_name (str): The name of the task. The splits will be saved in a directory with this name.
         output_dir (Path or str, optional): The output directory. Defaults to None (don't save anything).

--- a/tests/development-README.md
+++ b/tests/development-README.md
@@ -33,4 +33,4 @@ AutoPEP8 for formatting (this can be done automatically on save, see e.g. https:
 # Push release to PyPI
 1. Increase version in setup.py, and set below
 2. Build: `python -m build`
-3. Distribute package to PyPI: `python -m twine upload dist/*0.2.6*`
+3. Distribute package to PyPI: `python -m twine upload dist/*0.2.7*`

--- a/tests/development-README.md
+++ b/tests/development-README.md
@@ -33,4 +33,4 @@ AutoPEP8 for formatting (this can be done automatically on save, see e.g. https:
 # Push release to PyPI
 1. Increase version in setup.py, and set below
 2. Build: `python -m build`
-3. Distribute package to PyPI: `python -m twine upload dist/*0.2.8*`
+3. Distribute package to PyPI: `python -m twine upload dist/*0.2.9*`

--- a/tests/development-README.md
+++ b/tests/development-README.md
@@ -33,4 +33,4 @@ AutoPEP8 for formatting (this can be done automatically on save, see e.g. https:
 # Push release to PyPI
 1. Increase version in setup.py, and set below
 2. Build: `python -m build`
-3. Distribute package to PyPI: `python -m twine upload dist/*0.2.7*`
+3. Distribute package to PyPI: `python -m twine upload dist/*0.2.8*`

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,0 +1,15 @@
+from dragon_prep.ner import ner_tokenizer
+
+
+def test_tokenizer():
+    s = 'een "twee"->drie "vier" vijf?->zes zeven?'
+    tokenizer = ner_tokenizer()
+    tokenized_text = tokenizer(s)
+    text_parts = [token.text for token in tokenized_text]
+
+    print(text_parts)
+    assert text_parts == ['een', '"', 'twee', '"', '-', '>', 'drie', '"', 'vier', '"', 'vijf', '?', '-', '>', 'zes', 'zeven', '?']
+
+
+if __name__ == "__main__":
+    test_tokenizer()

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -2,13 +2,13 @@ from dragon_prep.ner import ner_tokenizer
 
 
 def test_tokenizer():
-    s = 'een "twee"->drie "vier" vijf?->zes zeven?'
+    s = 'een "twee"->drie "vier" vijf?->zes zeven? 8='
     tokenizer = ner_tokenizer()
     tokenized_text = tokenizer(s)
     text_parts = [token.text for token in tokenized_text]
 
     print(text_parts)
-    assert text_parts == ['een', '"', 'twee', '"', '-', '>', 'drie', '"', 'vier', '"', 'vijf', '?', '-', '>', 'zes', 'zeven', '?']
+    assert text_parts == ['een', '"', 'twee', '"', '-', '>', 'drie', '"', 'vier', '"', 'vijf', '?', '-', '>', 'zes', 'zeven', '?', '8=']
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Version Updates:
* Updated the Docker image version in `build.sh` and `setup.py` from `v0.2.6` to `v0.2.9`. This ensures the latest version of the application is used. [[1]](diffhunk://#diff-4d2a8eefdf2a9783512a35da4dc7676a66404b6f3826a8af9aad038722da6823L1-R1) [[2]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L8-R8)
* Updated dependencies in `requirements_dev.txt` to newer versions, including `twine` (5.1.1 → 6.1.0) and `build` (1.2.2 → 1.2.2.post1). Added `packaging==24.2` as a new dependency.

### Federated Task Scripts:
* Added new preprocessing scripts for federated learning tasks. These scripts handle data preparation, anonymization, and test split creation for specific tasks. [[1]](diffhunk://#diff-33e2e65504b6663caeb6b2a2a7d2d816676450aef6afb0b12f1a755debd0923eR1-R64) [[2]](diffhunk://#diff-6a75c8172d2fb20705ddf2a6ac4c8ffb161046029ac1550ad95417e946764ca3R1-R102) [[3]](diffhunk://#diff-f8a3298a990deb7468c0cb4b36be9aa00506b2fe04928e70e543549fb1170bb9R1-R64)
* Updated `preprocess_federated.sh` to include commands for running the new task scripts, enabling streamlined execution of preprocessing pipelines.

### Preprocessing Threshold Adjustments:
* Reduced thresholds for `<DATUM>` and `<TIJD>` tag counts in UMCG and AVL reports across multiple tasks (e.g., `Task010_prostate_radiology_clf.py`, `Task019_prostate_volume_reg.py`, `Task020_psa_reg.py`, `Task021_psad_reg.py`). These adjustments reflect updated data expectations. [[1]](diffhunk://#diff-2faa64cde7de0f1b1221011ee254682c99e34073806a7cbd994d75509fe6b38fL100-R101) [[2]](diffhunk://#diff-26090fd092c07e687fe6096af4bf5a535ddf376bab03929eb4f1b721489cc7d8L177-R180) [[3]](diffhunk://#diff-3a0084c14f142d25d160c1c05825c2897bb23b4a6443df2b3f3e133a0c247c5fL116-R119) [[4]](diffhunk://#diff-efe2a3eb73b6c7b629e4a7efbe62cf860f2e276c421d9ae928df590cd8926eccL108-R111)

### Data Enhancements:
* Added a new `lesion_GS` field to the `prepare_umcg_reports` function in `Task011_prostate_pathology_clf.py`. This field concatenates Gleason scores for lesions, improving data representation.

### Licensing and Documentation:
* Added Apache 2.0 license headers to new federated task scripts to ensure proper licensing and compliance. [[1]](diffhunk://#diff-33e2e65504b6663caeb6b2a2a7d2d816676450aef6afb0b12f1a755debd0923eR1-R64) [[2]](diffhunk://#diff-6a75c8172d2fb20705ddf2a6ac4c8ffb161046029ac1550ad95417e946764ca3R1-R102) [[3]](diffhunk://#diff-f8a3298a990deb7468c0cb4b36be9aa00506b2fe04928e70e543549fb1170bb9R1-R64)

### Additions
* Introduced a new "text_target", for generative tasks
* Added unit tests for the tokenizer